### PR TITLE
Fix handling of 'connected' message type from Chrome extension

### DIFF
--- a/internal/websocket/server.go
+++ b/internal/websocket/server.go
@@ -194,6 +194,16 @@ func (c *Connection) readPump() {
 			}); err != nil {
 				log.Printf("Failed to send pong message: %v", err)
 			}
+		case "connected":
+			// Handle connection confirmation from Chrome extension
+			log.Printf("Chrome extension connected successfully: %s", c.ID)
+			// Optionally send acknowledgment back
+			if err := c.SendMessage(&Message{
+				ID:   msg.ID,
+				Type: "ack",
+			}); err != nil {
+				log.Printf("Failed to send acknowledgment: %v", err)
+			}
 		default:
 			log.Printf("Unknown message type: %s", msg.Type)
 		}

--- a/internal/websocket/server.go
+++ b/internal/websocket/server.go
@@ -204,6 +204,16 @@ func (c *Connection) readPump() {
 			}); err != nil {
 				log.Printf("Failed to send acknowledgment: %v", err)
 			}
+		case "error":
+			// Handle error messages from Chrome extension
+			log.Printf("Chrome extension error (connection: %s): %s", c.ID, msg.Error)
+			if msg.Data != nil {
+				log.Printf("Error details: %s", string(msg.Data))
+			}
+			// If this is a response to a command, handle it appropriately
+			if msg.ID != "" {
+				c.server.browserClient.HandleResponse(msg.ID, nil, msg.Error)
+			}
 		default:
 			log.Printf("Unknown message type: %s", msg.Type)
 		}

--- a/internal/websocket/server_test.go
+++ b/internal/websocket/server_test.go
@@ -226,7 +226,7 @@ func TestServer_WebSocketIntegration(t *testing.T) {
 	require.NoError(t, err)
 	defer ws.Close()
 
-	// Send a ping message
+	// Test ping message
 	pingMsg := Message{
 		ID:   "test-ping",
 		Type: "ping",
@@ -240,6 +240,20 @@ func TestServer_WebSocketIntegration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test-ping", response.ID)
 	assert.Equal(t, "pong", response.Type)
+
+	// Test connected message
+	connectedMsg := Message{
+		ID:   "test-connected",
+		Type: "connected",
+	}
+	err = ws.WriteJSON(connectedMsg)
+	require.NoError(t, err)
+
+	// Should receive ack response
+	err = ws.ReadJSON(&response)
+	require.NoError(t, err)
+	assert.Equal(t, "test-connected", response.ID)
+	assert.Equal(t, "ack", response.Type)
 }
 
 func TestServer_HandleMessage(t *testing.T) {

--- a/internal/websocket/server_test.go
+++ b/internal/websocket/server_test.go
@@ -254,6 +254,19 @@ func TestServer_WebSocketIntegration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test-connected", response.ID)
 	assert.Equal(t, "ack", response.Type)
+
+	// Test error message (no response expected for error messages)
+	errorMsg := Message{
+		ID:    "test-error",
+		Type:  "error",
+		Error: "Test error message",
+		Data:  json.RawMessage(`{"code": "TEST_ERROR"}`),
+	}
+	err = ws.WriteJSON(errorMsg)
+	require.NoError(t, err)
+
+	// Give some time for the message to be processed
+	time.Sleep(50 * time.Millisecond)
 }
 
 func TestServer_HandleMessage(t *testing.T) {


### PR DESCRIPTION
## Summary
- Added proper handling for 'connected' message type sent by Chrome extension
- Added proper handling for 'error' message type sent by Chrome extension
- Server now acknowledges connection with 'ack' response instead of logging unknown message error
- Server now logs error messages with details and forwards them to browser client when appropriate
- Added test coverage for both new message types

## Test plan
- [x] Added unit test for 'connected' message type handling
- [x] Added unit test for 'error' message type handling
- [x] All existing tests pass
- [x] Built and tested locally - no more "Unknown message type" errors for 'connected' or 'error'