### PR TITLE
fix: handle list_tools as built-in MCP command

### DIFF
--- a/internal/dsl/runtime/runtime.go
+++ b/internal/dsl/runtime/runtime.go
@@ -119,6 +119,25 @@ func (rt *Runtime) executeCall(ctx context.Context, stmt *ast.CallStatement) err
 		return fmt.Errorf("not connected to any MCP server")
 	}
 
+	// Handle special built-in tools
+	if stmt.Tool == "list_tools" {
+		tools, err := rt.client.ListTools(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list tools: %w", err)
+		}
+
+		// Store result if variable specified
+		if stmt.Variable != "" {
+			// Convert tools to a simple list of names
+			toolNames := make([]interface{}, len(tools))
+			for i, tool := range tools {
+				toolNames[i] = tool.Name
+			}
+			rt.variables[stmt.Variable] = toolNames
+		}
+		return nil
+	}
+
 	// Evaluate arguments
 	var args interface{}
 	if stmt.Arguments != nil {


### PR DESCRIPTION
## Summary
- Fixed the "tool 'list_tools' not found" error by treating list_tools as a built-in command
- Added special handling in the DSL runtime to directly call the MCP client's ListTools() method
- The fix allows DSL scripts to properly list available tools from MCP servers

## Test plan
- [x] Tested with examples/mcp-test/basic.dsl - successfully lists all 20 browser automation tools
- [ ] Verify other MCP commands continue to work correctly
- [ ] Test with different MCP servers to ensure compatibility