### PR TITLE
Fix browser connection timing issue

### DIFF
--- a/examples/mcp-test/basic-browser-wait.dsl
+++ b/examples/mcp-test/basic-browser-wait.dsl
@@ -1,0 +1,32 @@
+# Basic Browser Connection Test
+# This script tests the browser extension connection with wait
+
+# Connect to the MCP browser server
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension to connect
+print "Waiting for browser extension to connect..."
+call browser_wait_for_connection {
+  timeout: 10
+} -> connection_result
+print "Connection result:"
+print connection_result
+
+# List available tools
+call list_tools -> tools
+print "Available browser tools:"
+print tools
+
+# Create a simple tab to verify connection works
+call browser_create_tab {
+  url: "about:blank",
+  active: true
+} -> tab
+print "Successfully created tab:"
+print tab
+
+# Clean up
+call browser_close_tab {
+  tabId: tab.id
+}
+print "✓ Basic browser test completed"

--- a/examples/mcp-test/basic.dsl
+++ b/examples/mcp-test/basic.dsl
@@ -2,7 +2,7 @@
 # This script tests basic connectivity and tool listing
 
 # Connect to the MCP browser server
-connect "./mcp-browser-server"
+connect "./bin/mcp-browser-server"
 
 # List available tools
 call list_tools -> tools

--- a/examples/mcp-test/browser-navigation.dsl
+++ b/examples/mcp-test/browser-navigation.dsl
@@ -2,15 +2,22 @@
 # Tests browser automation capabilities
 
 # Connect to the MCP browser server
-connect "./mcp-browser-server"
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension to connect
+call browser_wait_for_connection {
+  timeout: 5
+} -> connection_result
+print "Browser connection status:"
+print connection_result
 
 # Create a new tab
-call create_tab -> tab
+call browser_create_tab -> tab
 print "Created tab:"
 print tab
 
 # Navigate to a website
-call navigate {
+call browser_navigate {
   tabId: tab.id,
   url: "https://example.com"
 } -> result
@@ -22,7 +29,7 @@ print "✓ Successfully navigated to example.com"
 wait result.loaded == true, 5
 
 # Get page title
-call execute_script {
+call browser_execute_script {
   tabId: tab.id,
   script: "document.title"
 } -> title
@@ -30,7 +37,7 @@ call execute_script {
 print "Page title: " + title.result
 
 # Take a screenshot
-call screenshot {
+call browser_screenshot {
   tabId: tab.id
 } -> screenshot
 
@@ -38,7 +45,7 @@ assert screenshot.data != null, "Screenshot failed"
 print "✓ Screenshot captured"
 
 # Extract page content
-call extract_content {
+call browser_extract_content {
   tabId: tab.id,
   selector: "body"
 } -> content
@@ -46,7 +53,7 @@ call extract_content {
 print "Page content length: " + str(len(content.text))
 
 # Clean up - close the tab
-call close_tab {
+call browser_close_tab {
   tabId: tab.id
 }
 

--- a/internal/browser/client.go
+++ b/internal/browser/client.go
@@ -45,6 +45,32 @@ func (c *Client) SetConnection(conn Connection) {
 	c.connection = conn
 }
 
+// WaitForConnection waits for the WebSocket connection to be established
+func (c *Client) WaitForConnection(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			c.mu.RLock()
+			hasConnection := c.connection != nil
+			c.mu.RUnlock()
+			
+			if hasConnection {
+				return nil
+			}
+			
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timeout waiting for Chrome extension connection")
+			}
+		}
+	}
+}
+
 // RemoveConnection removes the WebSocket connection
 func (c *Client) RemoveConnection(conn Connection) {
 	c.mu.Lock()

--- a/internal/browser/client.go
+++ b/internal/browser/client.go
@@ -59,11 +59,11 @@ func (c *Client) WaitForConnection(ctx context.Context, timeout time.Duration) e
 			c.mu.RLock()
 			hasConnection := c.connection != nil
 			c.mu.RUnlock()
-			
+
 			if hasConnection {
 				return nil
 			}
-			
+
 			if time.Now().After(deadline) {
 				return fmt.Errorf("timeout waiting for Chrome extension connection")
 			}

--- a/internal/handler/browser_handler.go
+++ b/internal/handler/browser_handler.go
@@ -28,12 +28,12 @@ func NewBrowserHandler(client BrowserClient) *BrowserHandler {
 // WaitForConnection waits for the browser extension to connect
 func (h *BrowserHandler) WaitForConnection(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	timeout := time.Duration(request.GetFloat("timeout", 30)) * time.Second
-	
+
 	err := h.client.WaitForConnection(ctx, timeout)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to connect to browser: %v", err)), nil
 	}
-	
+
 	return mcp.NewToolResultText("Successfully connected to browser extension"), nil
 }
 

--- a/internal/handler/browser_handler.go
+++ b/internal/handler/browser_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/periplon/bract/internal/browser"
+	"time"
 )
 
 // BrowserHandler handles browser automation tool requests
@@ -20,6 +21,20 @@ func NewBrowserHandler(client BrowserClient) *BrowserHandler {
 	return &BrowserHandler{
 		client: client,
 	}
+}
+
+// Connection Handlers
+
+// WaitForConnection waits for the browser extension to connect
+func (h *BrowserHandler) WaitForConnection(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	timeout := time.Duration(request.GetFloat("timeout", 30)) * time.Second
+	
+	err := h.client.WaitForConnection(ctx, timeout)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to connect to browser: %v", err)), nil
+	}
+	
+	return mcp.NewToolResultText("Successfully connected to browser extension"), nil
 }
 
 // Tab Management Handlers

--- a/internal/handler/interfaces.go
+++ b/internal/handler/interfaces.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/periplon/bract/internal/browser"
 )
@@ -14,6 +15,7 @@ type BrowserClient interface {
 	RemoveConnection(conn browser.Connection)
 	HandleResponse(id string, data json.RawMessage, errMsg string)
 	HandleEvent(action string, data json.RawMessage)
+	WaitForConnection(ctx context.Context, timeout time.Duration) error
 
 	// Tab management
 	ListTabs(ctx context.Context) ([]browser.Tab, error)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -44,7 +44,7 @@ func (s *Server) Start() error {
 func (s *Server) registerTools() {
 	// Connection Tools
 	s.registerWaitForConnectionTool()
-	
+
 	// Tab Management Tools
 	s.registerTabListTool()
 	s.registerTabCreateTool()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -42,6 +42,9 @@ func (s *Server) Start() error {
 
 // registerTools registers all browser automation tools
 func (s *Server) registerTools() {
+	// Connection Tools
+	s.registerWaitForConnectionTool()
+	
 	// Tab Management Tools
 	s.registerTabListTool()
 	s.registerTabCreateTool()
@@ -66,6 +69,21 @@ func (s *Server) registerTools() {
 	// Storage Tools
 	s.registerCookieTools()
 	s.registerStorageTools()
+}
+
+// Connection Tools
+
+func (s *Server) registerWaitForConnectionTool() {
+	tool := mcp.NewTool("browser_wait_for_connection",
+		mcp.WithDescription("Wait for the browser extension to connect"),
+		mcp.WithNumber("timeout",
+			mcp.Description("Timeout in seconds (default: 30)"),
+		),
+	)
+
+	s.mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return s.handler.WaitForConnection(ctx, request)
+	})
 }
 
 // Tab Management Tools

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/periplon/bract/internal/browser"
 	"github.com/periplon/bract/internal/handler"
@@ -18,7 +19,10 @@ func (m *MockBrowserClient) SetConnection(conn browser.Connection)              
 func (m *MockBrowserClient) RemoveConnection(conn browser.Connection)                      {}
 func (m *MockBrowserClient) HandleResponse(id string, data json.RawMessage, errMsg string) {}
 func (m *MockBrowserClient) HandleEvent(action string, data json.RawMessage)               {}
-func (m *MockBrowserClient) ListTabs(ctx context.Context) ([]browser.Tab, error)           { return nil, nil }
+func (m *MockBrowserClient) WaitForConnection(ctx context.Context, timeout time.Duration) error {
+	return nil
+}
+func (m *MockBrowserClient) ListTabs(ctx context.Context) ([]browser.Tab, error) { return nil, nil }
 func (m *MockBrowserClient) CreateTab(ctx context.Context, url string, active bool) (*browser.Tab, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary
- Adds `browser_wait_for_connection` tool to wait for Chrome extension WebSocket connection
- Fixes "no connection to Chrome extension" error when creating tabs immediately after server start
- Updates DSL examples to use the wait command before browser operations

## Problem
When running `go run cmd/mcp-test/main.go examples/mcp-test/browser-navigation.dsl`, the script fails with:
```
Created tab:
{
  "type": "text",
  "text": "Failed to create tab: no connection to Chrome extension"
}
Execution failed
```

This happens because the DSL script tries to create a tab immediately after connecting to the MCP server, but the Chrome extension hasn't established its WebSocket connection yet.

## Solution
1. Added `WaitForConnection` method to the browser client that polls for an active WebSocket connection
2. Created `browser_wait_for_connection` MCP tool with configurable timeout (default 30s)
3. Updated DSL examples to wait for the connection before attempting browser operations

## Test plan
- [ ] Build the project: `go build ./...`
- [ ] Ensure Chrome extension is running
- [ ] Run the basic wait test: `go run cmd/mcp-test/main.go examples/mcp-test/basic-browser-wait.dsl`
- [ ] Run the browser navigation test: `go run cmd/mcp-test/main.go examples/mcp-test/browser-navigation.dsl`
- [ ] Verify tests complete without "no connection" errors