### PR TITLE
Fix MCP client tab creation errors

### DIFF
--- a/internal/handler/browser_handler.go
+++ b/internal/handler/browser_handler.go
@@ -73,8 +73,13 @@ func (h *BrowserHandler) CreateTab(ctx context.Context, request mcp.CallToolRequ
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to create tab: %v", err)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("Created new tab with ID %d\nURL: %s\nTitle: %s",
-		tab.ID, tab.URL, tab.Title)), nil
+	// Return tab data as JSON for structured access
+	tabJSON, err := json.Marshal(tab)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to serialize tab data: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(string(tabJSON)), nil
 }
 
 // CloseTab closes a browser tab

--- a/internal/handler/browser_handler_test.go
+++ b/internal/handler/browser_handler_test.go
@@ -378,8 +378,13 @@ func TestBrowserHandler_CreateTab(t *testing.T) {
 				assert.NotNil(t, result)
 				require.Len(t, result.Content, 1)
 				text := getTextFromContent(t, result.Content[0])
-				assert.Contains(t, text, "Created new tab")
-				assert.Contains(t, text, "Created new tab with ID 3")
+				// Check that the result is valid JSON
+				var tab browser.Tab
+				err := json.Unmarshal([]byte(text), &tab)
+				assert.NoError(t, err)
+				assert.Equal(t, 3, tab.ID)
+				assert.Equal(t, "https://example.com", tab.URL)
+				assert.Equal(t, "Example", tab.Title)
 			},
 		},
 		{
@@ -404,7 +409,13 @@ func TestBrowserHandler_CreateTab(t *testing.T) {
 				assert.NotNil(t, result)
 				require.Len(t, result.Content, 1)
 				text := getTextFromContent(t, result.Content[0])
-				assert.Contains(t, text, "Created new tab")
+				// Check that the result is valid JSON
+				var tab browser.Tab
+				err := json.Unmarshal([]byte(text), &tab)
+				assert.NoError(t, err)
+				assert.Equal(t, 4, tab.ID)
+				assert.Equal(t, "about:blank", tab.URL)
+				assert.Equal(t, "New Tab", tab.Title)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Fixes "Command not specified" error by properly mapping WebSocket message fields
- Fixes "cannot access field 'id' on mcp.TextContent" error by returning JSON data
- Maintains backward compatibility while supporting Chrome extension protocol

## Changes
1. **WebSocket Message Structure**: Added `command` and `params` fields that Chrome extension expects
2. **Command Mapping**: Created mapping from Go-style action names to Chrome extension command format
3. **JSON Response**: Changed CreateTab handler to return JSON instead of plain text
4. **Test Updates**: Updated tests to validate JSON response format

## Test Plan
- [x] All unit tests pass (`go test ./internal/handler` and `go test ./internal/websocket`)
- [x] Code is properly formatted
- [ ] Manual testing with Chrome extension and MCP client
- [ ] Verify tab creation works with both old and new DSL scripts