### PR TITLE
Fix missing screenshot command mapping in WebSocket server

### DIFF
--- a/internal/handler/browser_handler.go
+++ b/internal/handler/browser_handler.go
@@ -273,7 +273,8 @@ func (h *BrowserHandler) ExecuteScript(ctx context.Context, request mcp.CallTool
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to execute script: %v", err)), nil
 	}
 
-	// Return the raw script result as JSON
+	// The result from ExecuteScript is already JSON-encoded
+	// Return it as-is for proper parsing by the DSL runtime
 	return mcp.NewToolResultText(string(result)), nil
 }
 

--- a/internal/websocket/server.go
+++ b/internal/websocket/server.go
@@ -326,6 +326,7 @@ func mapActionToCommand(action string) string {
 		"goBack":            "tabs.goBack",
 		"goForward":         "tabs.goForward",
 		"executeScript":     "tabs.executeScript",
+		"screenshot":        "tabs.captureScreenshot",
 		"captureScreenshot": "tabs.captureScreenshot",
 		"captureVideo":      "tabs.captureVideo",
 		"extractText":       "tabs.extractText",


### PR DESCRIPTION
## Summary
- Fixed the "cannot access field 'dataUrl' on string" error when taking screenshots
- Added missing "screenshot" -> "tabs.captureScreenshot" mapping in WebSocket server

## Test plan
- [x] Build the mcp-browser-server binary
- [x] Run the browser-navigation.dsl test script
- [x] Verify that screenshot commands now work correctly
- [x] Confirm the dataUrl field is accessible in DSL scripts