### PR TITLE
Fix CSP error in browser-navigation.dsl

### DIFF
--- a/examples/mcp-test/browser-navigation.dsl
+++ b/examples/mcp-test/browser-navigation.dsl
@@ -27,11 +27,14 @@ print "✓ Successfully navigated to example.com"
 
 # Page is already loaded (navigate waits for load to complete)
 
-# Get page title
-call browser_execute_script {
-  tabId: tab.id,
-  script: "document.title"
-} -> title
+# Get page title using browser_list_tabs
+call browser_list_tabs -> tabs
+set title = ""
+loop t in tabs {
+  if t.id == tab.id {
+    set title = t.title
+  }
+}
 
 print "Page title: " + title
 


### PR DESCRIPTION
## Summary
- Fixed Content Security Policy error in browser-navigation.dsl
- Replaced `browser_execute_script` with `browser_list_tabs` to get page title
- This avoids CSP restrictions that prevent unsafe-eval

## Test plan
- [x] Run `./bin/mcp-test examples/mcp-test/browser-navigation.dsl`
- [x] Verify test passes without CSP errors
- [x] Confirm page title is correctly retrieved