### PR TITLE
Fix parse error in multi-tab.dsl

### DIFF
--- a/examples/mcp-test/multi-tab.dsl
+++ b/examples/mcp-test/multi-tab.dsl
@@ -2,28 +2,33 @@
 # Tests managing multiple browser tabs
 
 # Connect to the MCP browser server
-connect "./mcp-browser-server"
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension
+call browser_wait_for_connection {timeout: 5}
 
 # Create multiple tabs
-set tabs = []
-
 print "Creating 3 tabs..."
-loop i in [1, 2, 3] {
-  call create_tab -> tab
-  set tabs = tabs + [tab]
-  print "Created tab " + str(i) + ": " + tab.id
-}
+
+# Create tabs individually (workaround for array append limitation)
+call browser_create_tab -> tab1
+print "Created tab 1: " + str(tab1.id)
+
+call browser_create_tab -> tab2
+print "Created tab 2: " + str(tab2.id)
+
+call browser_create_tab -> tab3
+print "Created tab 3: " + str(tab3.id)
+
+# Store tabs in array
+set tabs = [tab1, tab2, tab3]
 
 # Navigate each tab to different pages
-set urls = [
-  "https://example.com",
-  "https://example.org",
-  "https://example.net"
-]
+set urls = ["https://example.com", "https://example.org", "https://example.net"]
 
 print "\nNavigating tabs..."
 loop i in [0, 1, 2] {
-  call navigate {
+  call browser_navigate {
     tabId: tabs[i].id,
     url: urls[i]
   }
@@ -31,29 +36,30 @@ loop i in [0, 1, 2] {
 }
 
 # List all tabs
-call list_tabs -> allTabs
+call browser_list_tabs -> allTabs
 print "\nTotal tabs open: " + str(len(allTabs))
 
 # Activate middle tab
-call activate_tab {
+call browser_activate_tab {
   tabId: tabs[1].id
 }
 print "✓ Activated tab 2"
 
-# Get title from each tab
+# Get title from each tab using browser_list_tabs
 print "\nGetting titles from all tabs..."
+call browser_list_tabs -> currentTabs
 loop i in [0, 1, 2] {
-  call execute_script {
-    tabId: tabs[i].id,
-    script: "document.title"
-  } -> title
-  print "Tab " + str(i + 1) + " title: " + title
+  loop tab in currentTabs {
+    if tab.id == tabs[i].id {
+      print "Tab " + str(i + 1) + " title: " + tab.title
+    }
+  }
 }
 
 # Close tabs in reverse order
 print "\nClosing tabs..."
 loop i in [2, 1, 0] {
-  call close_tab {
+  call browser_close_tab {
     tabId: tabs[i].id
   }
   print "Closed tab " + str(i + 1)


### PR DESCRIPTION
## Summary
- Fixed parse error caused by multi-line array syntax
- Resolved tool naming issues
- Worked around DSL array concatenation limitation
- Removed CSP-restricted execute_script calls

## Changes
1. Fixed all tool names to use `browser_` prefix
2. Changed multi-line array to single line format
3. Created tabs individually instead of in a loop (DSL doesn't support array append)
4. Used `browser_list_tabs` instead of `execute_script` to get tab titles

## Test plan
- [x] Run `./bin/mcp-test examples/mcp-test/multi-tab.dsl`
- [x] Verify test passes without parse errors
- [x] Confirm multi-tab operations work correctly