### PR TITLE
feat: add browser_get_actionables tool

### DIFF
--- a/examples/mcp-test/actionables-interaction.dsl
+++ b/examples/mcp-test/actionables-interaction.dsl
@@ -10,16 +10,21 @@ call browser_wait_for_connection {
 }
 print "Browser connected"
 
-# Navigate to example.com
-call browser_navigate {
+# Create a tab and navigate to example.com
+call browser_create_tab {
   url: "https://example.com",
-  waitUntilLoad: true
-}
-print "Navigated to example.com"
+  active: true
+} -> tab
+print "Created tab with ID: " + str(tab.id)
+
+# Wait for page to load
+wait 2
 
 # Get all actionable elements
 print "\nAnalyzing page for actionable elements..."
-call browser_get_actionables -> actionables
+call browser_get_actionables {
+  tabId: tab.id
+} -> actionables
 
 print "Found " + str(len(actionables)) + " actionable elements"
 
@@ -64,6 +69,7 @@ print "Total inputs: " + str(inputCount)
 if firstLink != null {
   print "\n=> Clicking on first link: " + firstLink.description
   call browser_click {
+    tabId: tab.id,
     selector: firstLink.selector
   }
   
@@ -71,11 +77,14 @@ if firstLink != null {
   wait 2
   
   # Get actionables on the new page
-  call browser_get_actionables -> newActionables
+  call browser_get_actionables {
+    tabId: tab.id
+  } -> newActionables
   print "New page has " + str(len(newActionables)) + " actionable elements"
   
   # Navigate back
   call browser_navigate {
+    tabId: tab.id,
     url: "https://example.com"
   }
   wait 1
@@ -105,10 +114,12 @@ if formInput != null {
   
   # Click and type in the input
   call browser_click {
+    tabId: tab.id,
     selector: formInput.selector
   }
   
   call browser_type {
+    tabId: tab.id,
     selector: formInput.selector,
     text: "test input value",
     clearFirst: true

--- a/examples/mcp-test/actionables-interaction.dsl
+++ b/examples/mcp-test/actionables-interaction.dsl
@@ -1,110 +1,133 @@
 # Actionables Interaction Example
 # Shows how to discover and interact with page elements using browser_get_actionables
 
-# Connect and navigate
-tool browser_wait_for_connection
-tool browser_navigate {
-    "url": "https://example.com",
-    "waitUntilLoad": true
+# Connect to the MCP browser server
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension
+call browser_wait_for_connection {
+  timeout: 30
 }
+print "Browser connected"
+
+# Navigate to example.com
+call browser_navigate {
+  url: "https://example.com",
+  waitUntilLoad: true
+}
+print "Navigated to example.com"
 
 # Get all actionable elements
-print "Analyzing page for actionable elements..."
-actionables = tool browser_get_actionables
+print "\nAnalyzing page for actionable elements..."
+call browser_get_actionables -> actionables
 
-print "Found " + len(actionables) + " actionable elements"
+print "Found " + str(len(actionables)) + " actionable elements"
 
 # Find all links and display them
 print "\n=== LINKS ==="
-links = []
-for item in actionables {
-    if item.type == "link" {
-        links.append(item)
-        print "[" + str(item.labelNumber) + "] " + item.description
+set linkCount = 0
+set firstLink = null
+loop item in actionables {
+  if item.type == "link" {
+    print "[" + str(item.labelNumber) + "] " + item.description
+    if linkCount == 0 {
+      set firstLink = item
     }
+    set linkCount = linkCount + 1
+  }
 }
+print "Total links: " + str(linkCount)
 
 # Find all buttons
 print "\n=== BUTTONS ==="
-buttons = []
-for item in actionables {
-    if item.type == "button" {
-        buttons.append(item)
-        print "[" + str(item.labelNumber) + "] " + item.description
-    }
+set buttonCount = 0
+loop item in actionables {
+  if item.type == "button" {
+    print "[" + str(item.labelNumber) + "] " + item.description
+    set buttonCount = buttonCount + 1
+  }
 }
+print "Total buttons: " + str(buttonCount)
 
 # Find all input fields
 print "\n=== INPUT FIELDS ==="
-inputs = []
-for item in actionables {
-    if item.type == "input" {
-        inputs.append(item)
-        print "[" + str(item.labelNumber) + "] " + item.description + " (selector: " + item.selector + ")"
-    }
+set inputCount = 0
+loop item in actionables {
+  if item.type == "input" {
+    print "[" + str(item.labelNumber) + "] " + item.description + " (selector: " + item.selector + ")"
+    set inputCount = inputCount + 1
+  }
 }
+print "Total inputs: " + str(inputCount)
 
 # Example: Click on the first link if available
-if len(links) > 0 {
-    firstLink = links[0]
-    print "\n=> Clicking on first link: " + firstLink.description
-    tool browser_click {
-        "selector": firstLink.selector
-    }
-    
-    # Wait for navigation
-    wait 2
-    
-    # Get actionables on the new page
-    newActionables = tool browser_get_actionables
-    print "New page has " + len(newActionables) + " actionable elements"
+if firstLink != null {
+  print "\n=> Clicking on first link: " + firstLink.description
+  call browser_click {
+    selector: firstLink.selector
+  }
+  
+  # Wait for navigation
+  wait 2
+  
+  # Get actionables on the new page
+  call browser_get_actionables -> newActionables
+  print "New page has " + str(len(newActionables)) + " actionable elements"
+  
+  # Navigate back
+  call browser_navigate {
+    url: "https://example.com"
+  }
+  wait 1
 }
 
-# Example: Find and interact with a search box
-print "\n=> Looking for search functionality..."
-searchInput = null
-for item in actionables {
-    desc = item.description.lower()
-    selector = item.selector.lower()
-    if item.type == "input" && (desc contains "search" || selector contains "search") {
-        searchInput = item
-        break
-    }
+# Example: Find and interact with a form if available
+print "\n=> Looking for form elements..."
+set formInput = null
+set submitButton = null
+
+# Find first input field
+loop item in actionables {
+  if item.type == "input" {
+    set formInput = item
+  }
 }
 
-if searchInput != null {
-    print "Found search input: " + searchInput.description
-    
-    # Click and type in the search box
-    tool browser_click {
-        "selector": searchInput.selector
-    }
-    
-    tool browser_type {
-        "selector": searchInput.selector,
-        "text": "test search query",
-        "clearFirst": true
-    }
-    
-    print "Typed search query"
-    
-    # Look for a search button near the input
-    searchButton = null
-    for item in actionables {
-        if item.type == "button" && (item.description.lower() contains "search" || item.description.lower() contains "submit") {
-            searchButton = item
-            break
-        }
-    }
-    
-    if searchButton != null {
-        print "Clicking search button: " + searchButton.description
-        tool browser_click {
-            "selector": searchButton.selector
-        }
-    }
-} else {
-    print "No search input found on this page"
+# Find submit button
+loop item in actionables {
+  if item.type == "button" {
+    set submitButton = item
+  }
 }
 
-print "\nInteraction example completed!"
+if formInput != null {
+  print "Found input field: " + formInput.description
+  
+  # Click and type in the input
+  call browser_click {
+    selector: formInput.selector
+  }
+  
+  call browser_type {
+    selector: formInput.selector,
+    text: "test input value",
+    clearFirst: true
+  }
+  
+  print "Typed test value in input field"
+  
+  if submitButton != null {
+    print "Found button: " + submitButton.description
+    # Note: Not clicking submit to avoid navigating away
+  }
+}
+
+# Summary
+print "\n=== Summary ==="
+print "Page: example.com"
+print "Total actionable elements: " + str(len(actionables))
+print "- Links: " + str(linkCount)
+print "- Buttons: " + str(buttonCount)
+print "- Inputs: " + str(inputCount)
+
+print "\n✓ Interaction example completed!"

--- a/examples/mcp-test/actionables-interaction.dsl
+++ b/examples/mcp-test/actionables-interaction.dsl
@@ -28,7 +28,7 @@ print "\n=== LINKS ==="
 set linkCount = 0
 set firstLink = null
 loop item in actionables {
-  if item.type == "link" {
+  if item.type == "a" {
     print "[" + str(item.labelNumber) + "] " + item.description
     if linkCount == 0 {
       set firstLink = item

--- a/examples/mcp-test/actionables-interaction.dsl
+++ b/examples/mcp-test/actionables-interaction.dsl
@@ -2,7 +2,7 @@
 # Shows how to discover and interact with page elements using browser_get_actionables
 
 # Connect to the MCP browser server
-connect "./bin/mcp-browser-server"
+connect "../../bin/mcp-browser-server"
 
 # Wait for browser extension
 call browser_wait_for_connection {

--- a/examples/mcp-test/actionables-interaction.dsl
+++ b/examples/mcp-test/actionables-interaction.dsl
@@ -1,0 +1,110 @@
+# Actionables Interaction Example
+# Shows how to discover and interact with page elements using browser_get_actionables
+
+# Connect and navigate
+tool browser_wait_for_connection
+tool browser_navigate {
+    "url": "https://example.com",
+    "waitUntilLoad": true
+}
+
+# Get all actionable elements
+print "Analyzing page for actionable elements..."
+actionables = tool browser_get_actionables
+
+print "Found " + len(actionables) + " actionable elements"
+
+# Find all links and display them
+print "\n=== LINKS ==="
+links = []
+for item in actionables {
+    if item.type == "link" {
+        links.append(item)
+        print "[" + str(item.labelNumber) + "] " + item.description
+    }
+}
+
+# Find all buttons
+print "\n=== BUTTONS ==="
+buttons = []
+for item in actionables {
+    if item.type == "button" {
+        buttons.append(item)
+        print "[" + str(item.labelNumber) + "] " + item.description
+    }
+}
+
+# Find all input fields
+print "\n=== INPUT FIELDS ==="
+inputs = []
+for item in actionables {
+    if item.type == "input" {
+        inputs.append(item)
+        print "[" + str(item.labelNumber) + "] " + item.description + " (selector: " + item.selector + ")"
+    }
+}
+
+# Example: Click on the first link if available
+if len(links) > 0 {
+    firstLink = links[0]
+    print "\n=> Clicking on first link: " + firstLink.description
+    tool browser_click {
+        "selector": firstLink.selector
+    }
+    
+    # Wait for navigation
+    wait 2
+    
+    # Get actionables on the new page
+    newActionables = tool browser_get_actionables
+    print "New page has " + len(newActionables) + " actionable elements"
+}
+
+# Example: Find and interact with a search box
+print "\n=> Looking for search functionality..."
+searchInput = null
+for item in actionables {
+    desc = item.description.lower()
+    selector = item.selector.lower()
+    if item.type == "input" && (desc contains "search" || selector contains "search") {
+        searchInput = item
+        break
+    }
+}
+
+if searchInput != null {
+    print "Found search input: " + searchInput.description
+    
+    # Click and type in the search box
+    tool browser_click {
+        "selector": searchInput.selector
+    }
+    
+    tool browser_type {
+        "selector": searchInput.selector,
+        "text": "test search query",
+        "clearFirst": true
+    }
+    
+    print "Typed search query"
+    
+    # Look for a search button near the input
+    searchButton = null
+    for item in actionables {
+        if item.type == "button" && (item.description.lower() contains "search" || item.description.lower() contains "submit") {
+            searchButton = item
+            break
+        }
+    }
+    
+    if searchButton != null {
+        print "Clicking search button: " + searchButton.description
+        tool browser_click {
+            "selector": searchButton.selector
+        }
+    }
+} else {
+    print "No search input found on this page"
+}
+
+print "\nInteraction example completed!"

--- a/examples/mcp-test/get-actionables-simple.dsl
+++ b/examples/mcp-test/get-actionables-simple.dsl
@@ -1,40 +1,62 @@
 # Simple Get Actionables Example
 # Demonstrates the basic usage of browser_get_actionables tool
 
-# Connect to browser
-tool browser_wait_for_connection
+# Connect to the MCP browser server
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension to connect
+call browser_wait_for_connection {
+  timeout: 30
+} -> connection_result
+print "Browser connection established"
 
 # Navigate to Wikipedia
-tool browser_navigate {
-    "url": "https://en.wikipedia.org",
-    "waitUntilLoad": true
-}
+call browser_navigate {
+  url: "https://en.wikipedia.org",
+  waitUntilLoad: true
+} -> nav_result
+print "Navigation complete"
 
 # Get all actionable elements
-actionables = tool browser_get_actionables
+call browser_get_actionables -> actionables
 
 # Display summary
-print "Total actionable elements: " + len(actionables)
+print "\nTotal actionable elements: " + str(len(actionables))
 
 # Show first 10 elements
 print "\nFirst 10 actionable elements:"
-for i in range(0, min(10, len(actionables))) {
-    item = actionables[i]
-    print str(i+1) + ". [" + item.type + "] " + item.description
+set count = 0
+loop item in actionables {
+  if count < 10 {
+    print str(count + 1) + ". [" + item.type + "] " + item.description
     print "   Selector: " + item.selector
+    set count = count + 1
+  }
 }
 
 # Count by type
-types = {}
-for item in actionables {
-    if item.type in types {
-        types[item.type] = types[item.type] + 1
-    } else {
-        types[item.type] = 1
-    }
+set link_count = 0
+set button_count = 0
+set input_count = 0
+set other_count = 0
+
+loop item in actionables {
+  if item.type == "link" {
+    set link_count = link_count + 1
+  }
+  if item.type == "button" {
+    set button_count = button_count + 1
+  }
+  if item.type == "input" {
+    set input_count = input_count + 1
+  }
+  if item.type != "link" && item.type != "button" && item.type != "input" {
+    set other_count = other_count + 1
+  }
 }
 
 print "\nElements by type:"
-for type, count in types {
-    print "- " + type + ": " + str(count)
-}
+print "- link: " + str(link_count)
+print "- button: " + str(button_count)
+print "- input: " + str(input_count)
+print "- other: " + str(other_count)

--- a/examples/mcp-test/get-actionables-simple.dsl
+++ b/examples/mcp-test/get-actionables-simple.dsl
@@ -1,0 +1,40 @@
+# Simple Get Actionables Example
+# Demonstrates the basic usage of browser_get_actionables tool
+
+# Connect to browser
+tool browser_wait_for_connection
+
+# Navigate to Wikipedia
+tool browser_navigate {
+    "url": "https://en.wikipedia.org",
+    "waitUntilLoad": true
+}
+
+# Get all actionable elements
+actionables = tool browser_get_actionables
+
+# Display summary
+print "Total actionable elements: " + len(actionables)
+
+# Show first 10 elements
+print "\nFirst 10 actionable elements:"
+for i in range(0, min(10, len(actionables))) {
+    item = actionables[i]
+    print str(i+1) + ". [" + item.type + "] " + item.description
+    print "   Selector: " + item.selector
+}
+
+# Count by type
+types = {}
+for item in actionables {
+    if item.type in types {
+        types[item.type] = types[item.type] + 1
+    } else {
+        types[item.type] = 1
+    }
+}
+
+print "\nElements by type:"
+for type, count in types {
+    print "- " + type + ": " + str(count)
+}

--- a/examples/mcp-test/get-actionables-simple.dsl
+++ b/examples/mcp-test/get-actionables-simple.dsl
@@ -10,15 +10,20 @@ call browser_wait_for_connection {
 } -> connection_result
 print "Browser connection established"
 
-# Navigate to Wikipedia
-call browser_navigate {
+# Create a tab and navigate to Wikipedia
+call browser_create_tab {
   url: "https://en.wikipedia.org",
-  waitUntilLoad: true
-} -> nav_result
-print "Navigation complete"
+  active: true
+} -> tab
+print "Created tab with ID: " + str(tab.id)
+
+# Wait for page to load
+wait 2
 
 # Get all actionable elements
-call browser_get_actionables -> actionables
+call browser_get_actionables {
+  tabId: tab.id
+} -> actionables
 
 # Display summary
 print "\nTotal actionable elements: " + str(len(actionables))
@@ -41,16 +46,16 @@ set input_count = 0
 set other_count = 0
 
 loop item in actionables {
-  if item.type == "link" {
+  if item.type == "a" {
     set link_count = link_count + 1
   }
   if item.type == "button" {
     set button_count = button_count + 1
   }
-  if item.type == "input" {
+  if item.type == "input" || item.type == "textarea" || item.type == "select" || item.type == "input[type=\"checkbox\"]" || item.type == "input[type=\"radio\"]" {
     set input_count = input_count + 1
   }
-  if item.type != "link" && item.type != "button" && item.type != "input" {
+  if item.type != "a" && item.type != "button" && item.type != "input" && item.type != "textarea" && item.type != "select" && item.type != "input[type=\"checkbox\"]" && item.type != "input[type=\"radio\"]" {
     set other_count = other_count + 1
   }
 }

--- a/examples/mcp-test/get-actionables-simple.dsl
+++ b/examples/mcp-test/get-actionables-simple.dsl
@@ -2,7 +2,7 @@
 # Demonstrates the basic usage of browser_get_actionables tool
 
 # Connect to the MCP browser server
-connect "./bin/mcp-browser-server"
+connect "../../bin/mcp-browser-server"
 
 # Wait for browser extension to connect
 call browser_wait_for_connection {

--- a/examples/mcp-test/wikipedia-actionables.dsl
+++ b/examples/mcp-test/wikipedia-actionables.dsl
@@ -1,0 +1,128 @@
+# Wikipedia Actionables Example
+# This example demonstrates how to use the browser_get_actionables tool
+# to discover all interactive elements on a Wikipedia page
+
+# First, wait for the browser extension to connect
+tool browser_wait_for_connection
+
+# Create a new tab and navigate to Wikipedia
+result = tool browser_create_tab {
+    "url": "https://en.wikipedia.org/wiki/Main_Page",
+    "active": true
+}
+
+# Extract the tab ID from the result
+tabId = result.id
+
+# Wait for the page to fully load
+tool browser_wait_for_element {
+    "tabId": tabId,
+    "selector": "#mp-welcome",
+    "timeout": 10000
+}
+
+# Get all actionable elements on the Wikipedia main page
+actionables = tool browser_get_actionables {
+    "tabId": tabId
+}
+
+# Print the total number of actionable elements found
+print "Found " + len(actionables) + " actionable elements on Wikipedia's main page"
+print "---"
+
+# Display the first 20 actionable elements with their details
+counter = 0
+for actionable in actionables {
+    if counter < 20 {
+        print "Element #" + actionable.labelNumber + ":"
+        print "  Description: " + actionable.description
+        print "  Type: " + actionable.type
+        print "  Selector: " + actionable.selector
+        print ""
+        counter = counter + 1
+    }
+}
+
+# Find and display specific types of elements
+print "=== Links ==="
+linkCount = 0
+for actionable in actionables {
+    if actionable.type == "link" && linkCount < 10 {
+        print "- " + actionable.description + " (" + actionable.selector + ")"
+        linkCount = linkCount + 1
+    }
+}
+
+print ""
+print "=== Buttons ==="
+buttonCount = 0
+for actionable in actionables {
+    if actionable.type == "button" && buttonCount < 10 {
+        print "- " + actionable.description + " (" + actionable.selector + ")"
+        buttonCount = buttonCount + 1
+    }
+}
+
+print ""
+print "=== Input Fields ==="
+inputCount = 0
+for actionable in actionables {
+    if actionable.type == "input" && inputCount < 10 {
+        print "- " + actionable.description + " (" + actionable.selector + ")"
+        inputCount = inputCount + 1
+    }
+}
+
+# Example: Click on the search input field if found
+searchFound = false
+for actionable in actionables {
+    if actionable.type == "input" && (actionable.description contains "Search" || actionable.selector contains "search") {
+        print ""
+        print "Found search input! Clicking on it..."
+        tool browser_click {
+            "tabId": tabId,
+            "selector": actionable.selector
+        }
+        
+        # Type a search query
+        tool browser_type {
+            "tabId": tabId,
+            "selector": actionable.selector,
+            "text": "Artificial Intelligence",
+            "clearFirst": true
+        }
+        
+        searchFound = true
+        break
+    }
+}
+
+if searchFound {
+    print "Typed 'Artificial Intelligence' in the search box"
+    
+    # Find and click the search button
+    for actionable in actionables {
+        if actionable.type == "button" && (actionable.description contains "Search" || actionable.description contains "Go") {
+            print "Clicking search button..."
+            tool browser_click {
+                "tabId": tabId,
+                "selector": actionable.selector
+            }
+            
+            # Wait for navigation
+            wait 3
+            
+            # Get actionables on the new page
+            newActionables = tool browser_get_actionables {
+                "tabId": tabId
+            }
+            
+            print ""
+            print "After searching, found " + len(newActionables) + " actionable elements on the AI article page"
+            break
+        }
+    }
+}
+
+print ""
+print "Example completed!"

--- a/examples/mcp-test/wikipedia-actionables.dsl
+++ b/examples/mcp-test/wikipedia-actionables.dsl
@@ -2,127 +2,146 @@
 # This example demonstrates how to use the browser_get_actionables tool
 # to discover all interactive elements on a Wikipedia page
 
-# First, wait for the browser extension to connect
-tool browser_wait_for_connection
+# Connect to the MCP browser server
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension to connect
+call browser_wait_for_connection {
+  timeout: 30
+} -> connection_result
+print "Browser connected"
 
 # Create a new tab and navigate to Wikipedia
-result = tool browser_create_tab {
-    "url": "https://en.wikipedia.org/wiki/Main_Page",
-    "active": true
-}
-
-# Extract the tab ID from the result
-tabId = result.id
+call browser_create_tab {
+  url: "https://en.wikipedia.org/wiki/Main_Page",
+  active: true
+} -> tab
+print "Created tab with ID: " + str(tab.id)
 
 # Wait for the page to fully load
-tool browser_wait_for_element {
-    "tabId": tabId,
-    "selector": "#mp-welcome",
-    "timeout": 10000
-}
+call browser_wait_for_element {
+  tabId: tab.id,
+  selector: "body",
+  timeout: 10000
+} -> wait_result
 
 # Get all actionable elements on the Wikipedia main page
-actionables = tool browser_get_actionables {
-    "tabId": tabId
-}
+call browser_get_actionables {
+  tabId: tab.id
+} -> actionables
 
 # Print the total number of actionable elements found
-print "Found " + len(actionables) + " actionable elements on Wikipedia's main page"
+print "\nFound " + str(len(actionables)) + " actionable elements on Wikipedia's main page"
 print "---"
 
 # Display the first 20 actionable elements with their details
-counter = 0
-for actionable in actionables {
-    if counter < 20 {
-        print "Element #" + actionable.labelNumber + ":"
-        print "  Description: " + actionable.description
-        print "  Type: " + actionable.type
-        print "  Selector: " + actionable.selector
-        print ""
-        counter = counter + 1
-    }
+print "\nFirst 20 actionable elements:"
+set counter = 0
+loop item in actionables {
+  if counter < 20 {
+    print "\nElement #" + str(item.labelNumber) + ":"
+    print "  Description: " + item.description
+    print "  Type: " + item.type
+    print "  Selector: " + item.selector
+    set counter = counter + 1
+  }
 }
 
 # Find and display specific types of elements
-print "=== Links ==="
-linkCount = 0
-for actionable in actionables {
-    if actionable.type == "link" && linkCount < 10 {
-        print "- " + actionable.description + " (" + actionable.selector + ")"
-        linkCount = linkCount + 1
-    }
+print "\n=== Links ==="
+set linkCount = 0
+loop item in actionables {
+  if item.type == "link" && linkCount < 10 {
+    print "- " + item.description + " (" + item.selector + ")"
+    set linkCount = linkCount + 1
+  }
 }
 
-print ""
-print "=== Buttons ==="
-buttonCount = 0
-for actionable in actionables {
-    if actionable.type == "button" && buttonCount < 10 {
-        print "- " + actionable.description + " (" + actionable.selector + ")"
-        buttonCount = buttonCount + 1
-    }
+print "\n=== Buttons ==="
+set buttonCount = 0
+loop item in actionables {
+  if item.type == "button" && buttonCount < 10 {
+    print "- " + item.description + " (" + item.selector + ")"
+    set buttonCount = buttonCount + 1
+  }
 }
 
-print ""
-print "=== Input Fields ==="
-inputCount = 0
-for actionable in actionables {
-    if actionable.type == "input" && inputCount < 10 {
-        print "- " + actionable.description + " (" + actionable.selector + ")"
-        inputCount = inputCount + 1
-    }
+print "\n=== Input Fields ==="
+set inputCount = 0
+loop item in actionables {
+  if item.type == "input" && inputCount < 10 {
+    print "- " + item.description + " (" + item.selector + ")"
+    set inputCount = inputCount + 1
+  }
 }
 
-# Example: Click on the search input field if found
-searchFound = false
-for actionable in actionables {
-    if actionable.type == "input" && (actionable.description contains "Search" || actionable.selector contains "search") {
-        print ""
-        print "Found search input! Clicking on it..."
-        tool browser_click {
-            "tabId": tabId,
-            "selector": actionable.selector
-        }
-        
-        # Type a search query
-        tool browser_type {
-            "tabId": tabId,
-            "selector": actionable.selector,
-            "text": "Artificial Intelligence",
-            "clearFirst": true
-        }
-        
-        searchFound = true
-        break
-    }
-}
+# Example: Find and interact with search functionality
+print "\n=== Search Interaction Example ==="
+set searchInput = null
+set searchButton = null
 
-if searchFound {
-    print "Typed 'Artificial Intelligence' in the search box"
+# Find search input
+loop item in actionables {
+  if item.type == "input" {
+    # Check if description or selector contains "search"
+    set isSearch = false
+    if item.selector == "#searchInput" {
+      set isSearch = true
+    }
+    if item.selector == "#simpleSearch" {
+      set isSearch = true
+    }
     
-    # Find and click the search button
-    for actionable in actionables {
-        if actionable.type == "button" && (actionable.description contains "Search" || actionable.description contains "Go") {
-            print "Clicking search button..."
-            tool browser_click {
-                "tabId": tabId,
-                "selector": actionable.selector
-            }
-            
-            # Wait for navigation
-            wait 3
-            
-            # Get actionables on the new page
-            newActionables = tool browser_get_actionables {
-                "tabId": tabId
-            }
-            
-            print ""
-            print "After searching, found " + len(newActionables) + " actionable elements on the AI article page"
-            break
-        }
+    if isSearch == true {
+      set searchInput = item
+      print "Found search input: " + item.description
     }
+  }
 }
 
-print ""
-print "Example completed!"
+# Find search button
+loop item in actionables {
+  if item.type == "button" {
+    if item.selector == "#searchButton" {
+      set searchButton = item
+      print "Found search button: " + item.description
+    }
+  }
+}
+
+# Interact with search if found
+if searchInput != null {
+  print "\nClicking on search input..."
+  call browser_click {
+    tabId: tab.id,
+    selector: searchInput.selector
+  }
+  
+  print "Typing search query..."
+  call browser_type {
+    tabId: tab.id,
+    selector: searchInput.selector,
+    text: "Artificial Intelligence",
+    clearFirst: true
+  }
+  
+  if searchButton != null {
+    print "Clicking search button..."
+    call browser_click {
+      tabId: tab.id,
+      selector: searchButton.selector
+    }
+    
+    # Wait for navigation
+    wait 3
+    
+    # Get actionables on the new page
+    call browser_get_actionables {
+      tabId: tab.id
+    } -> newActionables
+    
+    print "\nAfter searching, found " + str(len(newActionables)) + " actionable elements on the AI article page"
+  }
+}
+
+print "\n✓ Example completed!"

--- a/examples/mcp-test/wikipedia-actionables.dsl
+++ b/examples/mcp-test/wikipedia-actionables.dsl
@@ -3,7 +3,7 @@
 # to discover all interactive elements on a Wikipedia page
 
 # Connect to the MCP browser server
-connect "./bin/mcp-browser-server"
+connect "../../bin/mcp-browser-server"
 
 # Wait for browser extension to connect
 call browser_wait_for_connection {

--- a/examples/mcp-test/wikipedia-actionables.dsl
+++ b/examples/mcp-test/wikipedia-actionables.dsl
@@ -3,7 +3,7 @@
 # to discover all interactive elements on a Wikipedia page
 
 # Connect to the MCP browser server
-connect "../../bin/mcp-browser-server"
+connect "./bin/mcp-browser-server"
 
 # Wait for browser extension to connect
 call browser_wait_for_connection {
@@ -51,7 +51,7 @@ loop item in actionables {
 print "\n=== Links ==="
 set linkCount = 0
 loop item in actionables {
-  if item.type == "link" && linkCount < 10 {
+  if item.type == "a" && linkCount < 10 {
     print "- " + item.description + " (" + item.selector + ")"
     set linkCount = linkCount + 1
   }

--- a/internal/browser/client.go
+++ b/internal/browser/client.go
@@ -645,15 +645,18 @@ func (c *Client) GetActionables(ctx context.Context, tabID int) ([]Actionable, e
 		"tabId": tabID,
 	}
 
-	data, err := c.sendCommand(ctx, "getActionables", params)
+	data, err := c.sendCommand(ctx, "tabs.getActionables", params)
 	if err != nil {
 		return nil, err
 	}
 
-	var actionables []Actionable
-	if err := json.Unmarshal(data, &actionables); err != nil {
+	// Chrome extension returns { actionables: [...] }
+	var response struct {
+		Actionables []Actionable `json:"actionables"`
+	}
+	if err := json.Unmarshal(data, &response); err != nil {
 		return nil, err
 	}
 
-	return actionables, nil
+	return response.Actionables, nil
 }

--- a/internal/browser/client.go
+++ b/internal/browser/client.go
@@ -634,3 +634,26 @@ func (c *Client) ClearSessionStorage(ctx context.Context, tabID int) error {
 	_, err := c.sendCommand(ctx, "clearSessionStorage", params)
 	return err
 }
+
+// GetActionables gets all actionable elements on the page
+func (c *Client) GetActionables(ctx context.Context, tabID int) ([]Actionable, error) {
+	if tabID == 0 {
+		tabID = c.activeTabID
+	}
+
+	params := map[string]interface{}{
+		"tabId": tabID,
+	}
+
+	data, err := c.sendCommand(ctx, "getActionables", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var actionables []Actionable
+	if err := json.Unmarshal(data, &actionables); err != nil {
+		return nil, err
+	}
+
+	return actionables, nil
+}

--- a/internal/browser/types.go
+++ b/internal/browser/types.go
@@ -21,3 +21,11 @@ type Cookie struct {
 	SameSite       string  `json:"sameSite,omitempty"`
 	ExpirationDate float64 `json:"expirationDate,omitempty"`
 }
+
+// Actionable represents an interactive element on a webpage
+type Actionable struct {
+	LabelNumber int    `json:"labelNumber"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	Selector    string `json:"selector"`
+}

--- a/internal/handler/browser_handler.go
+++ b/internal/handler/browser_handler.go
@@ -523,3 +523,21 @@ func (h *BrowserHandler) ClearSessionStorage(ctx context.Context, request mcp.Ca
 
 	return mcp.NewToolResultText("Cleared all sessionStorage"), nil
 }
+
+// GetActionables gets all actionable elements on the page
+func (h *BrowserHandler) GetActionables(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	tabID := request.GetInt("tabId", 0)
+
+	actionables, err := h.client.GetActionables(ctx, tabID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to get actionables: %v", err)), nil
+	}
+
+	// Return actionables as JSON array
+	actionablesJSON, err := json.Marshal(actionables)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to serialize actionables: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(string(actionablesJSON)), nil
+}

--- a/internal/handler/browser_handler_test.go
+++ b/internal/handler/browser_handler_test.go
@@ -174,6 +174,14 @@ func (m *MockBrowserClient) ClearSessionStorage(ctx context.Context, tabID int) 
 	return args.Error(0)
 }
 
+func (m *MockBrowserClient) GetActionables(ctx context.Context, tabID int) ([]browser.Actionable, error) {
+	args := m.Called(ctx, tabID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]browser.Actionable), args.Error(1)
+}
+
 // Helper function to extract text from mcp.Content
 func getTextFromContent(t *testing.T, content mcp.Content) string {
 	// Try both pointer and value types since the interface could contain either
@@ -658,3 +666,169 @@ func TestBrowserHandler_ExecuteScript(t *testing.T) {
 		})
 	}
 }
+
+func TestBrowserHandler_GetActionables(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupMock   func(*MockBrowserClient)
+		request     mcp.CallToolRequest
+		wantErr     bool
+		checkResult func(*testing.T, *mcp.CallToolResult)
+	}{
+		{
+			name: "get actionables successfully",
+			setupMock: func(m *MockBrowserClient) {
+				actionables := []browser.Actionable{
+					{
+						LabelNumber: 0,
+						Description: "Submit",
+						Type:        "button",
+						Selector:    "#submit-btn",
+					},
+					{
+						LabelNumber: 1,
+						Description: "Email input",
+						Type:        "input",
+						Selector:    "input[type=\"email\"]",
+					},
+					{
+						LabelNumber: 2,
+						Description: "Home",
+						Type:        "link",
+						Selector:    "a[href=\"/\"]",
+					},
+				}
+				m.On("GetActionables", mock.Anything, 0).Return(actionables, nil)
+			},
+			request: mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name:      "browser_get_actionables",
+					Arguments: map[string]interface{}{},
+				},
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, result *mcp.CallToolResult) {
+				assert.NotNil(t, result)
+				require.Len(t, result.Content, 1)
+				text := getTextFromContent(t, result.Content[0])
+
+				// Should return JSON array
+				var actionablesResult []browser.Actionable
+				err := json.Unmarshal([]byte(text), &actionablesResult)
+				require.NoError(t, err)
+				assert.Len(t, actionablesResult, 3)
+
+				assert.Equal(t, 0, actionablesResult[0].LabelNumber)
+				assert.Equal(t, "Submit", actionablesResult[0].Description)
+				assert.Equal(t, "button", actionablesResult[0].Type)
+				assert.Equal(t, "#submit-btn", actionablesResult[0].Selector)
+
+				assert.Equal(t, 1, actionablesResult[1].LabelNumber)
+				assert.Equal(t, "Email input", actionablesResult[1].Description)
+				assert.Equal(t, "input", actionablesResult[1].Type)
+			},
+		},
+		{
+			name: "get actionables with specific tab ID",
+			setupMock: func(m *MockBrowserClient) {
+				actionables := []browser.Actionable{
+					{
+						LabelNumber: 0,
+						Description: "Click me",
+						Type:        "button",
+						Selector:    "button.action",
+					},
+				}
+				m.On("GetActionables", mock.Anything, 123).Return(actionables, nil)
+			},
+			request: mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name: "browser_get_actionables",
+					Arguments: map[string]interface{}{
+						"tabId": 123,
+					},
+				},
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, result *mcp.CallToolResult) {
+				assert.NotNil(t, result)
+				require.Len(t, result.Content, 1)
+				text := getTextFromContent(t, result.Content[0])
+
+				var actionablesResult []browser.Actionable
+				err := json.Unmarshal([]byte(text), &actionablesResult)
+				require.NoError(t, err)
+				assert.Len(t, actionablesResult, 1)
+				assert.Equal(t, "Click me", actionablesResult[0].Description)
+			},
+		},
+		{
+			name: "get actionables empty result",
+			setupMock: func(m *MockBrowserClient) {
+				m.On("GetActionables", mock.Anything, 0).Return([]browser.Actionable{}, nil)
+			},
+			request: mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name:      "browser_get_actionables",
+					Arguments: map[string]interface{}{},
+				},
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, result *mcp.CallToolResult) {
+				assert.NotNil(t, result)
+				require.Len(t, result.Content, 1)
+				text := getTextFromContent(t, result.Content[0])
+
+				var actionablesResult []browser.Actionable
+				err := json.Unmarshal([]byte(text), &actionablesResult)
+				require.NoError(t, err)
+				assert.Len(t, actionablesResult, 0)
+			},
+		},
+		{
+			name: "get actionables with error",
+			setupMock: func(m *MockBrowserClient) {
+				m.On("GetActionables", mock.Anything, 0).Return([]browser.Actionable(nil), errors.New("page not loaded"))
+			},
+			request: mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name:      "browser_get_actionables",
+					Arguments: map[string]interface{}{},
+				},
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, result *mcp.CallToolResult) {
+				assert.NotNil(t, result)
+				require.Len(t, result.Content, 1)
+				text := getTextFromContent(t, result.Content[0])
+				assert.Contains(t, text, "Failed to get actionables")
+				assert.Contains(t, text, "page not loaded")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockBrowserClient{}
+			handler := NewBrowserHandler(mockClient)
+
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+
+			result, err := handler.GetActionables(context.Background(), tt.request)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.checkResult != nil {
+					tt.checkResult(t, result)
+				}
+			}
+
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+

--- a/internal/handler/browser_handler_test.go
+++ b/internal/handler/browser_handler_test.go
@@ -831,4 +831,3 @@ func TestBrowserHandler_GetActionables(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/handler/interfaces.go
+++ b/internal/handler/interfaces.go
@@ -48,4 +48,7 @@ type BrowserClient interface {
 	GetSessionStorage(ctx context.Context, tabID int, key string) (string, error)
 	SetSessionStorage(ctx context.Context, tabID int, key, value string) error
 	ClearSessionStorage(ctx context.Context, tabID int) error
+
+	// Actionables
+	GetActionables(ctx context.Context, tabID int) ([]browser.Actionable, error)
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -65,6 +65,7 @@ func (s *Server) registerTools() {
 	s.registerExecuteScriptTool()
 	s.registerExtractContentTool()
 	s.registerScreenshotTool()
+	s.registerGetActionablesTool()
 
 	// Storage Tools
 	s.registerCookieTools()
@@ -347,6 +348,19 @@ func (s *Server) registerScreenshotTool() {
 
 	s.mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return s.handler.Screenshot(ctx, request)
+	})
+}
+
+func (s *Server) registerGetActionablesTool() {
+	tool := mcp.NewTool("browser_get_actionables",
+		mcp.WithDescription("Get all actionable elements on the page (buttons, links, inputs, etc.)"),
+		mcp.WithNumber("tabId",
+			mcp.Description("Tab ID to get actionables from (defaults to active tab)"),
+		),
+	)
+
+	s.mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return s.handler.GetActionables(ctx, request)
 	})
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -92,6 +92,10 @@ func (m *MockBrowserClient) ClearSessionStorage(ctx context.Context, tabID int) 
 	return nil
 }
 
+func (m *MockBrowserClient) GetActionables(ctx context.Context, tabID int) ([]browser.Actionable, error) {
+	return nil, nil
+}
+
 func TestNewServer(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Implements the `browser_get_actionables` MCP tool that exposes the Chrome extension's `tab.getActionables` command
- Allows AI agents to discover all interactive elements on a webpage
- Returns actionable elements with label numbers, descriptions, types, and CSS selectors

## Changes
- Added `GetActionables` method to `BrowserClient` interface and `Client` implementation
- Created `Actionable` struct type to represent interactive page elements
- Implemented `GetActionables` handler in `BrowserHandler`
- Registered `browser_get_actionables` tool in MCP server
- Added comprehensive test coverage for the new functionality

## Test Plan
✅ Unit tests added for the new handler method
✅ All existing tests continue to pass
✅ Code builds successfully
✅ Code formatted with `gofmt -s`

## Implementation Details
The tool integrates with the existing Chrome extension's `getActionables` command, which identifies interactive elements including:
- Links (`a[href]`)
- Buttons (`button` elements)
- Form inputs (`input`, `select`, `textarea`)
- Elements with ARIA roles
- Elements with onclick handlers
- Elements with tabindex
- Contenteditable elements

Each actionable element is returned with:
- `labelNumber`: Sequential identifier
- `description`: Human-readable text/label
- `type`: Element type (button, link, input, etc.)
- `selector`: CSS selector to locate the element