### PR TITLE
Add browser_extract_text tool for plain text extraction

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -82,7 +82,30 @@ Comprehensive scrolling capabilities.
 - Scroll to elements
 - Horizontal scrolling
 
-### 5. Storage Management
+### 5. Content Extraction
+
+#### [extract-text.dsl](mcp-test/extract-text.dsl)
+Extract plain text from web pages.
+- Extract all text content from a page
+- Target specific elements with CSS selectors
+- Clean text output without HTML tags
+- Ideal for content analysis and reading
+
+#### [extract-article-text.dsl](mcp-test/extract-article-text.dsl)
+Advanced article extraction and analysis.
+- Extract article titles and body text
+- Estimate word count and reading time
+- Extract metadata (author, date, tags)
+- Fallback strategies for different site structures
+
+#### [compare-extract-tools.dsl](mcp-test/compare-extract-tools.dsl)
+Compare different content extraction methods.
+- browser_extract_content vs browser_extract_text
+- HTML extraction vs plain text extraction
+- Performance and output format comparison
+- Use case demonstrations
+
+### 6. Storage Management
 
 #### [storage-test.dsl](mcp-test/storage-test.dsl)
 Complete storage testing suite.
@@ -105,7 +128,7 @@ Advanced cookie operations.
 - Handle httpOnly cookies
 - Bulk cookie operations
 
-### 6. Advanced Automation
+### 7. Advanced Automation
 
 #### [advanced-automation.dsl](mcp-test/advanced-automation.dsl)
 Complex automation patterns.
@@ -205,7 +228,8 @@ run myFunction("arg1", "arg2")
 
 ### Content
 - `browser_execute_script` - Execute JavaScript
-- `browser_extract_content` - Extract page content
+- `browser_extract_content` - Extract page content as HTML or text array
+- `browser_extract_text` - Extract page content as plain text
 - `browser_screenshot` - Take a screenshot
 
 ### Storage

--- a/examples/mcp-test/compare-extract-tools.dsl
+++ b/examples/mcp-test/compare-extract-tools.dsl
@@ -1,0 +1,72 @@
+// Compare browser_extract_content vs browser_extract_text
+// This example shows the difference between extracting HTML content
+// and plain text from web pages
+
+// Connect to browser extension
+connect
+
+print("Comparing content extraction methods...")
+print("=====================================\n")
+
+// Define selector for comparison
+selector = "p"  // Extract all paragraphs
+
+// Method 1: Extract HTML content
+print("1. Using browser_extract_content (HTML):")
+htmlContent -> browser_extract_content({
+    selector: selector,
+    type: "html"
+})
+print("HTML content (first item):")
+if (len(htmlContent) > 0) {
+    print(htmlContent[0])
+    print("Total items: " + str(len(htmlContent)))
+}
+
+// Method 2: Extract as plain text using browser_extract_content
+print("\n\n2. Using browser_extract_content (text mode):")
+textArray -> browser_extract_content({
+    selector: selector,
+    type: "text"
+})
+print("Text array (first 3 items):")
+for (i in [0, 1, 2]) {
+    if (i < len(textArray)) {
+        print("  [" + str(i) + "]: " + textArray[i])
+    }
+}
+print("Total items: " + str(len(textArray)))
+
+// Method 3: Extract as plain text using browser_extract_text
+print("\n\n3. Using browser_extract_text (new tool):")
+plainText -> browser_extract_text({
+    selector: selector
+})
+print("Plain text (first 500 chars):")
+print(plainText[0:500] + "...")
+print("Total length: " + str(len(plainText)) + " characters")
+
+// Key differences
+print("\n\nKey Differences:")
+print("================")
+print("- browser_extract_content returns an array of strings (one per element)")
+print("- browser_extract_text returns a single string with all text combined")
+print("- browser_extract_text strips ALL HTML tags and cleans up formatting")
+print("- browser_extract_text is ideal for reading content, text analysis, etc.")
+
+// Practical example: Word count
+print("\n\nPractical Example - Word Count:")
+words = plainText.split(" ")
+wordCount = len(words)
+print("Total words in all paragraphs: " + str(wordCount))
+
+// Find longest word
+longestWord = ""
+for (word in words) {
+    if (len(word) > len(longestWord)) {
+        longestWord = word
+    }
+}
+print("Longest word: " + longestWord + " (" + str(len(longestWord)) + " chars)")
+
+print("\n\nComparison complete!")

--- a/examples/mcp-test/compare-extract-tools.dsl
+++ b/examples/mcp-test/compare-extract-tools.dsl
@@ -1,72 +1,90 @@
-// Compare browser_extract_content vs browser_extract_text
-// This example shows the difference between extracting HTML content
-// and plain text from web pages
+# Compare browser_extract_content vs browser_extract_text
+# This example shows the difference between extracting HTML content
+# and plain text from web pages
 
-// Connect to browser extension
-connect
+# Connect to browser extension server
+connect "./bin/mcp-browser-server"
 
-print("Comparing content extraction methods...")
-print("=====================================\n")
+# Wait for browser extension to connect
+call browser_wait_for_connection {
+    timeout: 5
+} -> connection_result
+print "Browser connection status:"
+print connection_result
 
-// Define selector for comparison
-selector = "p"  // Extract all paragraphs
+print "\nComparing content extraction methods..."
+print "====================================="
 
-// Method 1: Extract HTML content
-print("1. Using browser_extract_content (HTML):")
-htmlContent -> browser_extract_content({
+# Define selector for comparison
+set selector = "p"  # Extract all paragraphs
+
+# Method 1: Extract HTML content
+print "\n1. Using browser_extract_content (HTML):"
+call browser_extract_content {
     selector: selector,
     type: "html"
-})
-print("HTML content (first item):")
-if (len(htmlContent) > 0) {
-    print(htmlContent[0])
-    print("Total items: " + str(len(htmlContent)))
+} -> htmlContent
+print "HTML content items: " + str(len(htmlContent))
+if len(htmlContent) > 0 {
+    print "First item (HTML):"
+    print htmlContent[0]
 }
 
-// Method 2: Extract as plain text using browser_extract_content
-print("\n\n2. Using browser_extract_content (text mode):")
-textArray -> browser_extract_content({
+# Method 2: Extract as plain text using browser_extract_content
+print "\n\n2. Using browser_extract_content (text mode):"
+call browser_extract_content {
     selector: selector,
     type: "text"
-})
-print("Text array (first 3 items):")
-for (i in [0, 1, 2]) {
-    if (i < len(textArray)) {
-        print("  [" + str(i) + "]: " + textArray[i])
+} -> textArray
+print "Text array items: " + str(len(textArray))
+if len(textArray) > 0 {
+    print "First 3 items:"
+    set count = 0
+    loop item in textArray {
+        if count < 3 {
+            print "  [" + str(count) + "]: " + item
+            set count = count + 1
+        }
     }
 }
-print("Total items: " + str(len(textArray)))
 
-// Method 3: Extract as plain text using browser_extract_text
-print("\n\n3. Using browser_extract_text (new tool):")
-plainText -> browser_extract_text({
+# Method 3: Extract as plain text using browser_extract_text
+print "\n\n3. Using browser_extract_text (new tool):"
+call browser_extract_text {
     selector: selector
-})
-print("Plain text (first 500 chars):")
-print(plainText[0:500] + "...")
-print("Total length: " + str(len(plainText)) + " characters")
+} -> plainText
+print "Plain text length: " + str(len(plainText)) + " characters"
 
-// Key differences
-print("\n\nKey Differences:")
-print("================")
-print("- browser_extract_content returns an array of strings (one per element)")
-print("- browser_extract_text returns a single string with all text combined")
-print("- browser_extract_text strips ALL HTML tags and cleans up formatting")
-print("- browser_extract_text is ideal for reading content, text analysis, etc.")
+# Key differences
+print "\n\nKey Differences:"
+print "================"
+print "- browser_extract_content returns an array of strings (one per element)"
+print "- browser_extract_text returns a single string with all text combined"
+print "- browser_extract_text strips ALL HTML tags and cleans up formatting"
+print "- browser_extract_text is ideal for reading content, text analysis, etc."
 
-// Practical example: Word count
-print("\n\nPractical Example - Word Count:")
-words = plainText.split(" ")
-wordCount = len(words)
-print("Total words in all paragraphs: " + str(wordCount))
-
-// Find longest word
-longestWord = ""
-for (word in words) {
-    if (len(word) > len(longestWord)) {
-        longestWord = word
-    }
+# Practical example: Character count comparison
+print "\n\nPractical Example - Character Count:"
+set totalCharsInArray = 0
+loop item in textArray {
+    set totalCharsInArray = totalCharsInArray + len(item)
 }
-print("Longest word: " + longestWord + " (" + str(len(longestWord)) + " chars)")
+print "Total chars in extract_content array: " + str(totalCharsInArray)
+print "Total chars in extract_text: " + str(len(plainText))
 
-print("\n\nComparison complete!")
+# Show extraction from different element types
+print "\n\nExtracting from different elements:"
+
+# Links
+call browser_extract_text {
+    selector: "a"
+} -> linkText
+print "All link text combined: " + str(len(linkText)) + " characters"
+
+# Lists
+call browser_extract_text {
+    selector: "li"
+} -> listText
+print "All list item text combined: " + str(len(listText)) + " characters"
+
+print "\n\n✓ Comparison complete!"

--- a/examples/mcp-test/extract-article-text.dsl
+++ b/examples/mcp-test/extract-article-text.dsl
@@ -1,0 +1,78 @@
+// Extract and analyze article text from news/blog websites
+// This example shows how to extract clean text from articles
+// and perform basic text analysis
+
+// Connect to browser extension
+connect
+
+// Common article selectors for popular websites
+articleSelectors = "article, main article, .post-content, .entry-content, .article-body, .story-body, [itemprop='articleBody']"
+
+// Extract article title
+print("Extracting article title...")
+title -> browser_extract_text({
+    selector: "h1, article h1, .article-title, .post-title, [itemprop='headline']"
+})
+print("Title: " + title)
+
+// Extract article content
+print("\nExtracting article content...")
+articleText -> browser_extract_text({
+    selector: articleSelectors
+})
+
+if (len(articleText) > 0) {
+    // Basic text analysis
+    wordCount = len(articleText.split(" "))
+    charCount = len(articleText)
+    
+    print("Article Analysis:")
+    print("- Word count: " + str(wordCount))
+    print("- Character count: " + str(charCount))
+    print("- Estimated reading time: " + str(wordCount / 200) + " minutes")
+    
+    // Extract first paragraph as summary
+    paragraphs = articleText.split("\n\n")
+    if (len(paragraphs) > 0) {
+        print("\nFirst paragraph (summary):")
+        print(paragraphs[0])
+    }
+    
+    // Save to variable for further processing
+    print("\nArticle text extracted successfully!")
+    print("Text is now available in 'articleText' variable")
+    
+    // Example: Search for keywords
+    keywords = ["AI", "technology", "innovation", "future"]
+    print("\nKeyword analysis:")
+    for (keyword in keywords) {
+        if (articleText.indexOf(keyword) != -1) {
+            print("- Found keyword: " + keyword)
+        }
+    }
+} else {
+    print("No article content found. This might not be an article page.")
+    print("Trying to extract all text content...")
+    
+    // Fallback: extract all text
+    allText -> browser_extract_text()
+    print("Total text extracted: " + str(len(allText)) + " characters")
+}
+
+// Extract metadata if available
+print("\nExtracting metadata...")
+author -> browser_extract_text({
+    selector: ".author, .by-author, .article-author, [itemprop='author']"
+})
+if (len(author) > 0) {
+    print("Author: " + author)
+}
+
+date -> browser_extract_text({
+    selector: "time, .publish-date, .article-date, [itemprop='datePublished']"
+})
+if (len(date) > 0) {
+    print("Date: " + date)
+}
+
+print("\nExtraction complete!")

--- a/examples/mcp-test/extract-text.dsl
+++ b/examples/mcp-test/extract-text.dsl
@@ -1,0 +1,54 @@
+// Extract plain text from current browser tab
+// This example demonstrates using the browser_extract_text tool
+// to get clean, readable text content from web pages
+
+// Connect to browser extension
+connect
+
+// Extract text from the entire page (body element)
+print("Extracting text from entire page...")
+pageText -> browser_extract_text()
+print("Page text length: " + str(len(pageText)))
+print("First 500 characters:")
+print(pageText[0:500] + "...")
+
+// Extract text from specific elements
+print("\n\nExtracting text from specific elements...")
+
+// Extract main content (adjust selector based on the website)
+mainContent -> browser_extract_text({
+    selector: "main, article, [role='main'], .content, #content"
+})
+if (len(mainContent) > 0) {
+    print("Main content found (" + str(len(mainContent)) + " characters)")
+    print("Preview: " + mainContent[0:200] + "...")
+} else {
+    print("No main content found with common selectors")
+}
+
+// Extract all headings
+print("\n\nExtracting all headings...")
+headings -> browser_extract_text({
+    selector: "h1, h2, h3, h4, h5, h6"
+})
+print("Headings found:")
+print(headings)
+
+// Extract navigation links
+print("\n\nExtracting navigation text...")
+navText -> browser_extract_text({
+    selector: "nav, header, .navigation, .nav, .menu"
+})
+if (len(navText) > 0) {
+    print("Navigation text (" + str(len(navText)) + " characters):")
+    print(navText[0:200] + "...")
+}
+
+// Extract specific content by ID or class
+// Uncomment and adjust selector for your specific use case
+// specificContent -> browser_extract_text({
+//     selector: "#specific-id, .specific-class"
+// })
+// print("Specific content: " + specificContent)
+
+print("\n\nText extraction complete!")

--- a/examples/mcp-test/extract-text.dsl
+++ b/examples/mcp-test/extract-text.dsl
@@ -1,54 +1,60 @@
-// Extract plain text from current browser tab
-// This example demonstrates using the browser_extract_text tool
-// to get clean, readable text content from web pages
+# Extract plain text from current browser tab
+# This example demonstrates using the browser_extract_text tool
+# to get clean, readable text content from web pages
 
-// Connect to browser extension
-connect
+# Connect to browser extension server
+connect "./bin/mcp-browser-server"
 
-// Extract text from the entire page (body element)
-print("Extracting text from entire page...")
-pageText -> browser_extract_text()
-print("Page text length: " + str(len(pageText)))
-print("First 500 characters:")
-print(pageText[0:500] + "...")
+# Wait for browser extension to connect
+call browser_wait_for_connection {
+    timeout: 5
+} -> connection_result
+print "Browser connection status:"
+print connection_result
 
-// Extract text from specific elements
-print("\n\nExtracting text from specific elements...")
+# Extract text from the entire page (body element)
+print "\nExtracting text from entire page..."
+call browser_extract_text -> pageText
+print "Page text length: " + str(len(pageText))
 
-// Extract main content (adjust selector based on the website)
-mainContent -> browser_extract_text({
+# Extract text from specific elements
+print "\n\nExtracting text from specific elements..."
+
+# Extract main content (adjust selector based on the website)
+call browser_extract_text {
     selector: "main, article, [role='main'], .content, #content"
-})
-if (len(mainContent) > 0) {
-    print("Main content found (" + str(len(mainContent)) + " characters)")
-    print("Preview: " + mainContent[0:200] + "...")
+} -> mainContent
+
+if len(mainContent) > 0 {
+    print "Main content found (" + str(len(mainContent)) + " characters)"
 } else {
-    print("No main content found with common selectors")
+    print "No main content found with common selectors"
 }
 
-// Extract all headings
-print("\n\nExtracting all headings...")
-headings -> browser_extract_text({
+# Extract all headings
+print "\n\nExtracting all headings..."
+call browser_extract_text {
     selector: "h1, h2, h3, h4, h5, h6"
-})
-print("Headings found:")
-print(headings)
+} -> headings
+print "Headings text length: " + str(len(headings))
 
-// Extract navigation links
-print("\n\nExtracting navigation text...")
-navText -> browser_extract_text({
+# Extract navigation links
+print "\n\nExtracting navigation text..."
+call browser_extract_text {
     selector: "nav, header, .navigation, .nav, .menu"
-})
-if (len(navText) > 0) {
-    print("Navigation text (" + str(len(navText)) + " characters):")
-    print(navText[0:200] + "...")
+} -> navText
+
+if len(navText) > 0 {
+    print "Navigation text found (" + str(len(navText)) + " characters)"
+} else {
+    print "No navigation text found"
 }
 
-// Extract specific content by ID or class
-// Uncomment and adjust selector for your specific use case
-// specificContent -> browser_extract_text({
-//     selector: "#specific-id, .specific-class"
-// })
-// print("Specific content: " + specificContent)
+# Extract paragraphs
+print "\n\nExtracting paragraph text..."
+call browser_extract_text {
+    selector: "p"
+} -> paragraphText
+print "Paragraph text length: " + str(len(paragraphText))
 
-print("\n\nText extraction complete!")
+print "\n\n✓ Text extraction complete!"

--- a/internal/browser/client.go
+++ b/internal/browser/client.go
@@ -686,21 +686,23 @@ func (c *Client) ExtractText(ctx context.Context, tabID int, selector string) (s
 // stripHTMLTags removes HTML tags from a string and returns plain text
 func stripHTMLTags(html string) string {
 	// Remove script and style tags and their contents
-	scriptStyleRegex := regexp.MustCompile(`(?i)<(script|style)[^>]*>[\s\S]*?</\1>`)
-	html = scriptStyleRegex.ReplaceAllString(html, "")
-	
+	scriptRegex := regexp.MustCompile(`(?i)<script[^>]*>[\s\S]*?</script>`)
+	html = scriptRegex.ReplaceAllString(html, "")
+	styleRegex := regexp.MustCompile(`(?i)<style[^>]*>[\s\S]*?</style>`)
+	html = styleRegex.ReplaceAllString(html, "")
+
 	// Replace br tags with newlines
 	brRegex := regexp.MustCompile(`(?i)<br\s*/?>`)
 	html = brRegex.ReplaceAllString(html, "\n")
-	
+
 	// Replace p, div, and other block tags with newlines
 	blockRegex := regexp.MustCompile(`(?i)</?(p|div|h[1-6]|ul|ol|li|blockquote|pre|table|tr|td|th)[^>]*>`)
 	html = blockRegex.ReplaceAllString(html, "\n")
-	
+
 	// Remove all remaining HTML tags
 	tagRegex := regexp.MustCompile(`<[^>]+>`)
 	text := tagRegex.ReplaceAllString(html, "")
-	
+
 	// Decode HTML entities
 	text = strings.ReplaceAll(text, "&amp;", "&")
 	text = strings.ReplaceAll(text, "&lt;", "<")
@@ -708,7 +710,7 @@ func stripHTMLTags(html string) string {
 	text = strings.ReplaceAll(text, "&quot;", "\"")
 	text = strings.ReplaceAll(text, "&#39;", "'")
 	text = strings.ReplaceAll(text, "&nbsp;", " ")
-	
+
 	// Clean up excessive whitespace
 	lines := strings.Split(text, "\n")
 	var cleanedLines []string
@@ -718,6 +720,6 @@ func stripHTMLTags(html string) string {
 			cleanedLines = append(cleanedLines, trimmed)
 		}
 	}
-	
+
 	return strings.Join(cleanedLines, "\n")
 }

--- a/internal/browser/client.go
+++ b/internal/browser/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -659,4 +661,63 @@ func (c *Client) GetActionables(ctx context.Context, tabID int) ([]Actionable, e
 	}
 
 	return response.Actionables, nil
+}
+
+// ExtractText extracts content from the page as HTML and converts it to plain text
+func (c *Client) ExtractText(ctx context.Context, tabID int, selector string) (string, error) {
+	// Use the existing extractContent command with type "html"
+	results, err := c.ExtractContent(ctx, tabID, selector, "html", "")
+	if err != nil {
+		return "", err
+	}
+
+	// Join all results and strip HTML tags
+	var plainText strings.Builder
+	for i, html := range results {
+		if i > 0 {
+			plainText.WriteString("\n\n")
+		}
+		plainText.WriteString(stripHTMLTags(html))
+	}
+
+	return plainText.String(), nil
+}
+
+// stripHTMLTags removes HTML tags from a string and returns plain text
+func stripHTMLTags(html string) string {
+	// Remove script and style tags and their contents
+	scriptStyleRegex := regexp.MustCompile(`(?i)<(script|style)[^>]*>[\s\S]*?</\1>`)
+	html = scriptStyleRegex.ReplaceAllString(html, "")
+	
+	// Replace br tags with newlines
+	brRegex := regexp.MustCompile(`(?i)<br\s*/?>`)
+	html = brRegex.ReplaceAllString(html, "\n")
+	
+	// Replace p, div, and other block tags with newlines
+	blockRegex := regexp.MustCompile(`(?i)</?(p|div|h[1-6]|ul|ol|li|blockquote|pre|table|tr|td|th)[^>]*>`)
+	html = blockRegex.ReplaceAllString(html, "\n")
+	
+	// Remove all remaining HTML tags
+	tagRegex := regexp.MustCompile(`<[^>]+>`)
+	text := tagRegex.ReplaceAllString(html, "")
+	
+	// Decode HTML entities
+	text = strings.ReplaceAll(text, "&amp;", "&")
+	text = strings.ReplaceAll(text, "&lt;", "<")
+	text = strings.ReplaceAll(text, "&gt;", ">")
+	text = strings.ReplaceAll(text, "&quot;", "\"")
+	text = strings.ReplaceAll(text, "&#39;", "'")
+	text = strings.ReplaceAll(text, "&nbsp;", " ")
+	
+	// Clean up excessive whitespace
+	lines := strings.Split(text, "\n")
+	var cleanedLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			cleanedLines = append(cleanedLines, trimmed)
+		}
+	}
+	
+	return strings.Join(cleanedLines, "\n")
 }

--- a/internal/handler/browser_handler.go
+++ b/internal/handler/browser_handler.go
@@ -541,3 +541,17 @@ func (h *BrowserHandler) GetActionables(ctx context.Context, request mcp.CallToo
 
 	return mcp.NewToolResultText(string(actionablesJSON)), nil
 }
+
+// ExtractText extracts content from the page and returns it as plain text
+func (h *BrowserHandler) ExtractText(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	selector := request.GetString("selector", "body")
+	tabID := request.GetInt("tabId", 0)
+
+	text, err := h.client.ExtractText(ctx, tabID, selector)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to extract text: %v", err)), nil
+	}
+
+	// Return as plain text
+	return mcp.NewToolResultText(text), nil
+}

--- a/internal/handler/browser_handler_test.go
+++ b/internal/handler/browser_handler_test.go
@@ -118,6 +118,11 @@ func (m *MockBrowserClient) ExtractContent(ctx context.Context, tabID int, selec
 	return args.Get(0).([]string), args.Error(1)
 }
 
+func (m *MockBrowserClient) ExtractText(ctx context.Context, tabID int, selector string) (string, error) {
+	args := m.Called(ctx, tabID, selector)
+	return args.String(0), args.Error(1)
+}
+
 func (m *MockBrowserClient) Screenshot(ctx context.Context, tabID int, fullPage bool, selector, format string, quality int) (string, error) {
 	args := m.Called(ctx, tabID, fullPage, selector, format, quality)
 	return args.String(0), args.Error(1)

--- a/internal/handler/interfaces.go
+++ b/internal/handler/interfaces.go
@@ -36,6 +36,7 @@ type BrowserClient interface {
 	// Content
 	ExecuteScript(ctx context.Context, tabID int, script string, args []interface{}) (json.RawMessage, error)
 	ExtractContent(ctx context.Context, tabID int, selector, contentType, attribute string) ([]string, error)
+	ExtractText(ctx context.Context, tabID int, selector string) (string, error)
 	Screenshot(ctx context.Context, tabID int, fullPage bool, selector, format string, quality int) (string, error)
 
 	// Storage

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -64,6 +64,7 @@ func (s *Server) registerTools() {
 	// Content Tools
 	s.registerExecuteScriptTool()
 	s.registerExtractContentTool()
+	s.registerExtractTextTool()
 	s.registerScreenshotTool()
 	s.registerGetActionablesTool()
 
@@ -322,6 +323,22 @@ func (s *Server) registerExtractContentTool() {
 
 	s.mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return s.handler.ExtractContent(ctx, request)
+	})
+}
+
+func (s *Server) registerExtractTextTool() {
+	tool := mcp.NewTool("browser_extract_text",
+		mcp.WithDescription("Extract content from the page and convert it to plain text"),
+		mcp.WithString("selector",
+			mcp.Description("CSS selector for element(s) to extract (defaults to 'body')"),
+		),
+		mcp.WithNumber("tabId",
+			mcp.Description("Tab ID to extract from (defaults to active tab)"),
+		),
+	)
+
+	s.mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return s.handler.ExtractText(ctx, request)
 	})
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -56,6 +56,10 @@ func (m *MockBrowserClient) ExtractContent(ctx context.Context, tabID int, selec
 	return nil, nil
 }
 
+func (m *MockBrowserClient) ExtractText(ctx context.Context, tabID int, selector string) (string, error) {
+	return "", nil
+}
+
 func (m *MockBrowserClient) Screenshot(ctx context.Context, tabID int, fullPage bool, selector, format string, quality int) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
## Summary
- Add new `browser_extract_text` tool that extracts content from web pages and converts it to plain text
- Uses existing browser extension's `extractContent` command with HTML mode
- Strips all HTML tags, scripts, and styles to return clean plain text output

## Implementation Details
The tool reuses the existing `extractContent` browser extension command rather than adding a new command. It:
1. Calls `extractContent` with `type: "html"` to get HTML content
2. Processes the HTML through a comprehensive `stripHTMLTags` function that:
   - Removes script and style tags with their contents
   - Converts block-level tags to newlines for proper formatting
   - Removes all remaining HTML tags
   - Decodes common HTML entities
   - Cleans up excessive whitespace

## Changes
- Added `ExtractText` handler method in `browser_handler.go`
- Added `ExtractText` method to browser client in `client.go`
- Added `stripHTMLTags` utility function for HTML to plain text conversion
- Registered `browser_extract_text` tool in `server.go`
- Updated `BrowserClient` interface with the new `ExtractText` method

## Test Plan
- [x] Code compiles successfully (`go build ./...`)
- [x] Existing tests pass (`go test ./internal/browser -v`)
- [ ] Manual testing with browser extension to verify plain text extraction works correctly
- [ ] Test with various HTML content including scripts, styles, and nested tags