### PR TITLE
feat: implement browser_get_accessibility_snapshot tool

### DIFF
--- a/examples/mcp-test/accessibility-current-tab.dsl
+++ b/examples/mcp-test/accessibility-current-tab.dsl
@@ -4,6 +4,7 @@
 # Prerequisites:
 # 1. Browser with Perix extension installed
 # 2. Extension connected to the WebSocket server
+# 3. A web page loaded in at least one tab
 
 # Connect to the MCP browser server
 connect "./bin/mcp-browser-server"
@@ -15,20 +16,77 @@ print connection_result
 
 print "\n=== Accessibility Snapshot of Current Tab ==="
 
-# Get accessibility snapshot of the current active tab (tabId defaults to 0 = active tab)
-print "Getting accessibility snapshot..."
-call browser_get_accessibility_snapshot {} -> snapshot_result
+# First check if there are any tabs
+call browser_list_tabs -> tabs
+set tabToUse = null
+
+if len(tabs) == 0 {
+  print "\nNo tabs found. Creating a new tab..."
+  call browser_create_tab {
+    url: "https://example.com",
+    active: true
+  } -> new_tab
+  print "Created new tab with ID: " + str(new_tab.id)
+  set tabToUse = new_tab
+  
+  # Wait for page to load
+  print "Waiting for page to load..."
+  call browser_wait_for_element {
+    tabId: new_tab.id,
+    selector: "body",
+    timeout: 5000
+  }
+} else {
+  # Use the first tab and activate it
+  set tabToUse = tabs[0]
+  print "\nFound " + str(len(tabs)) + " tab(s). Using tab ID: " + str(tabToUse.id)
+  print "Tab URL: " + tabToUse.url
+  
+  # Activate the tab to ensure it's the current active tab
+  call browser_activate_tab {
+    tabId: tabToUse.id
+  }
+  print "Activated tab: " + str(tabToUse.id)
+  
+  # Wait a moment for the tab to be ready
+  print "Ensuring page is loaded..."
+  call browser_wait_for_element {
+    tabId: tabToUse.id,
+    selector: "body",
+    timeout: 2000
+  }
+}
+
+# Get accessibility snapshot of the specific tab
+print "\nGetting accessibility snapshot for tab " + str(tabToUse.id) + "..."
+call browser_get_accessibility_snapshot {
+  tabId: tabToUse.id,
+  interestingOnly: true
+} -> snapshot_result
 
 # The result is returned as a JSON string
 print "\nResult received!"
-print "Length: " + str(len(str(snapshot_result))) + " characters"
+set result_str = str(snapshot_result)
+print "Length: " + str(len(result_str)) + " characters"
 
-# Just print the full result - in a real app you'd parse this JSON
-print "\nAccessibility snapshot:"
-print snapshot_result
+# Check if we got a valid snapshot
+if result_str == "{\"snapshot\":null}" || result_str == "null" {
+  print "\nWarning: Received null snapshot. This can happen when:"
+  print "- The page is still loading"
+  print "- The page has no accessible content"
+  print "- The browser extension needs to be refreshed"
+  print "\nTry refreshing the page or navigating to a content-rich website."
+} else {
+  print "\nAccessibility snapshot received successfully!"
+  print "The snapshot contains the accessibility tree structure of the page."
+  
+  # Since we can't parse JSON in DSL, just show the length
+  if len(result_str) > 500 {
+    print "\nSnapshot size: " + str(len(result_str)) + " characters (large accessibility tree)"
+  } else {
+    print "\nSnapshot data:"
+    print result_str
+  }
+}
 
 print "\n✓ Example completed!"
-print "\nNote: If you see an error above, make sure:"
-print "1. Browser with Perix extension is open"
-print "2. Extension is connected (check extension popup)"
-print "3. A web page is loaded in the active tab"

--- a/examples/mcp-test/accessibility-current-tab.dsl
+++ b/examples/mcp-test/accessibility-current-tab.dsl
@@ -70,8 +70,8 @@ set result_str = str(snapshot_result)
 print "Length: " + str(len(result_str)) + " characters"
 
 # Check if we got a valid snapshot
-if result_str == "{\"snapshot\":null}" || result_str == "null" {
-  print "\nWarning: Received null snapshot. This can happen when:"
+if result_str == "{}" || result_str == "null" {
+  print "\nWarning: Received empty snapshot. This can happen when:"
   print "- The page is still loading"
   print "- The page has no accessible content"
   print "- The browser extension needs to be refreshed"

--- a/examples/mcp-test/accessibility-current-tab.dsl
+++ b/examples/mcp-test/accessibility-current-tab.dsl
@@ -1,77 +1,34 @@
 # Get Accessibility Snapshot of Current Tab
 # Simple example showing how to analyze the accessibility tree of the active tab
+#
+# Prerequisites:
+# 1. Browser with Perix extension installed
+# 2. Extension connected to the WebSocket server
 
 # Connect to the MCP browser server
 connect "./bin/mcp-browser-server"
 
 # Wait for browser extension
-call browser_wait_for_connection {timeout: 5}
+print "Waiting for browser extension connection..."
+call browser_wait_for_connection {timeout: 30} -> connection_result
+print connection_result
 
-print "=== Accessibility Snapshot of Current Tab ==="
+print "\n=== Accessibility Snapshot of Current Tab ==="
 
 # Get accessibility snapshot of the current active tab (tabId defaults to 0 = active tab)
-call browser_get_accessibility_snapshot {} -> snapshot
+print "Getting accessibility snapshot..."
+call browser_get_accessibility_snapshot {} -> snapshot_result
 
-# Display basic information
-print "\nPage Accessibility Information:"
-print "Role: " + snapshot.role
-if snapshot.name {
-  print "Name: " + snapshot.name
-}
+# The result is returned as a JSON string
+print "\nResult received!"
+print "Length: " + str(len(str(snapshot_result))) + " characters"
 
-# Count different types of elements
-elementCounts = {}
+# Just print the full result - in a real app you'd parse this JSON
+print "\nAccessibility snapshot:"
+print snapshot_result
 
-function countElements(node) {
-  role = node.role || "unknown"
-  if elementCounts[role] {
-    elementCounts[role] = elementCounts[role] + 1
-  } else {
-    elementCounts[role] = 1
-  }
-  
-  if node.children {
-    for child in node.children {
-      countElements(child)
-    }
-  }
-}
-
-countElements(snapshot)
-
-print "\nElement Types Found:"
-for role in Object.keys(elementCounts).sort() {
-  print "  " + role + ": " + elementCounts[role]
-}
-
-# Show page structure
-print "\nPage Structure (first 2 levels):"
-function showStructure(node, indent, maxDepth) {
-  if maxDepth <= 0 {
-    return
-  }
-  
-  prefix = "  ".repeat(indent)
-  nodeInfo = node.role
-  if node.name {
-    nodeInfo = nodeInfo + ' "' + node.name + '"'
-  }
-  
-  print prefix + "- " + nodeInfo
-  
-  if node.children && node.children.length > 0 {
-    # Show up to 5 children per level
-    childrenToShow = Math.min(node.children.length, 5)
-    for i in range(0, childrenToShow) {
-      showStructure(node.children[i], indent + 1, maxDepth - 1)
-    }
-    
-    if node.children.length > 5 {
-      print prefix + "  ... and " + (node.children.length - 5) + " more"
-    }
-  }
-}
-
-showStructure(snapshot, 0, 2)
-
-print "\n✓ Accessibility analysis complete!"
+print "\n✓ Example completed!"
+print "\nNote: If you see an error above, make sure:"
+print "1. Browser with Perix extension is open"
+print "2. Extension is connected (check extension popup)"
+print "3. A web page is loaded in the active tab"

--- a/examples/mcp-test/accessibility-current-tab.dsl
+++ b/examples/mcp-test/accessibility-current-tab.dsl
@@ -1,0 +1,77 @@
+# Get Accessibility Snapshot of Current Tab
+# Simple example showing how to analyze the accessibility tree of the active tab
+
+# Connect to the MCP browser server
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension
+call browser_wait_for_connection {timeout: 5}
+
+print "=== Accessibility Snapshot of Current Tab ==="
+
+# Get accessibility snapshot of the current active tab (tabId defaults to 0 = active tab)
+call browser_get_accessibility_snapshot {} -> snapshot
+
+# Display basic information
+print "\nPage Accessibility Information:"
+print "Role: " + snapshot.role
+if snapshot.name {
+  print "Name: " + snapshot.name
+}
+
+# Count different types of elements
+elementCounts = {}
+
+function countElements(node) {
+  role = node.role || "unknown"
+  if elementCounts[role] {
+    elementCounts[role] = elementCounts[role] + 1
+  } else {
+    elementCounts[role] = 1
+  }
+  
+  if node.children {
+    for child in node.children {
+      countElements(child)
+    }
+  }
+}
+
+countElements(snapshot)
+
+print "\nElement Types Found:"
+for role in Object.keys(elementCounts).sort() {
+  print "  " + role + ": " + elementCounts[role]
+}
+
+# Show page structure
+print "\nPage Structure (first 2 levels):"
+function showStructure(node, indent, maxDepth) {
+  if maxDepth <= 0 {
+    return
+  }
+  
+  prefix = "  ".repeat(indent)
+  nodeInfo = node.role
+  if node.name {
+    nodeInfo = nodeInfo + ' "' + node.name + '"'
+  }
+  
+  print prefix + "- " + nodeInfo
+  
+  if node.children && node.children.length > 0 {
+    # Show up to 5 children per level
+    childrenToShow = Math.min(node.children.length, 5)
+    for i in range(0, childrenToShow) {
+      showStructure(node.children[i], indent + 1, maxDepth - 1)
+    }
+    
+    if node.children.length > 5 {
+      print prefix + "  ... and " + (node.children.length - 5) + " more"
+    }
+  }
+}
+
+showStructure(snapshot, 0, 2)
+
+print "\n✓ Accessibility analysis complete!"

--- a/examples/mcp-test/accessibility-snapshot.dsl
+++ b/examples/mcp-test/accessibility-snapshot.dsl
@@ -1,0 +1,133 @@
+# Accessibility Snapshot Example
+# Demonstrates how to get the accessibility tree of a web page
+
+# Connect to the MCP browser server
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension
+call browser_wait_for_connection {timeout: 5}
+
+# List existing tabs
+call browser_list_tabs -> tabs
+
+if tabs.length == 0 {
+  # Create a new tab if none exist
+  call browser_create_tab {
+    url: "https://www.w3.org/WAI/ARIA/apg/patterns/",
+    active: true
+  } -> tab
+} else {
+  # Use the first tab
+  tab = tabs[0]
+  
+  # Navigate to the ARIA patterns page
+  call browser_navigate {
+    tabId: tab.id,
+    url: "https://www.w3.org/WAI/ARIA/apg/patterns/"
+  }
+}
+
+print "=== Accessibility Snapshot Example ==="
+print "Current tab: " + tab.title + " (" + tab.url + ")"
+
+# Wait for page to load
+call browser_wait_for_element {
+  tabId: tab.id,
+  selector: "main",
+  timeout: 5000
+}
+
+# Get the full accessibility snapshot
+print "\n1. Full Accessibility Snapshot (interesting nodes only):"
+call browser_get_accessibility_snapshot {
+  tabId: tab.id,
+  interestingOnly: true
+} -> snapshot
+
+print "Root role: " + snapshot.role
+print "Page name: " + snapshot.name
+print "Number of direct children: " + snapshot.children.length
+
+# Get a more detailed snapshot (all nodes)
+print "\n2. Detailed Accessibility Snapshot (all nodes):"
+call browser_get_accessibility_snapshot {
+  tabId: tab.id,
+  interestingOnly: false
+} -> detailedSnapshot
+
+print "Total accessible elements found (including all nodes)"
+
+# Get accessibility snapshot of a specific region
+print "\n3. Accessibility Snapshot of Main Content:"
+call browser_get_accessibility_snapshot {
+  tabId: tab.id,
+  interestingOnly: true,
+  root: "main"
+} -> mainSnapshot
+
+print "Main content role: " + mainSnapshot.role
+if mainSnapshot.name {
+  print "Main content name: " + mainSnapshot.name
+}
+
+# Find all headings in the accessibility tree
+print "\n4. Finding Headings in Accessibility Tree:"
+headings = []
+
+function findHeadings(node) {
+  if node.role == "heading" {
+    headings.push({
+      name: node.name,
+      level: node.level
+    })
+  }
+  
+  if node.children {
+    for child in node.children {
+      findHeadings(child)
+    }
+  }
+}
+
+findHeadings(snapshot)
+
+print "Found " + headings.length + " headings:"
+for heading in headings {
+  print "  Level " + heading.level + ": " + heading.name
+}
+
+# Find all interactive elements
+print "\n5. Finding Interactive Elements:"
+interactiveElements = []
+
+function findInteractive(node) {
+  interactiveRoles = ["button", "link", "textbox", "checkbox", "radio", "combobox", "menuitem"]
+  
+  if interactiveRoles.includes(node.role) {
+    interactiveElements.push({
+      role: node.role,
+      name: node.name || "(unnamed)",
+      disabled: node.disabled || false
+    })
+  }
+  
+  if node.children {
+    for child in node.children {
+      findInteractive(child)
+    }
+  }
+}
+
+findInteractive(snapshot)
+
+print "Found " + interactiveElements.length + " interactive elements:"
+for elem in interactiveElements.slice(0, 10) {  # Show first 10
+  status = elem.disabled ? " (disabled)" : ""
+  print "  " + elem.role + ": " + elem.name + status
+}
+
+if interactiveElements.length > 10 {
+  print "  ... and " + (interactiveElements.length - 10) + " more"
+}
+
+print "\n✓ Accessibility snapshot example completed!"

--- a/examples/mcp-test/accessibility-test-simple.dsl
+++ b/examples/mcp-test/accessibility-test-simple.dsl
@@ -1,0 +1,18 @@
+# Simple Accessibility Snapshot Test
+# Tests the basic functionality of browser_get_accessibility_snapshot
+
+# Connect to the MCP browser server
+connect "./bin/mcp-browser-server"
+
+# Wait for browser extension
+call browser_wait_for_connection {timeout: 5}
+
+print "=== Testing Accessibility Snapshot Tool ==="
+
+# Get snapshot and just print it as-is to see what we get
+call browser_get_accessibility_snapshot {} -> result
+
+print "\nRaw result:"
+print result
+
+print "\n✓ Test completed!"

--- a/examples/mcp-test/accessibility-test-simple.dsl
+++ b/examples/mcp-test/accessibility-test-simple.dsl
@@ -36,8 +36,8 @@ call browser_get_accessibility_snapshot {
 
 set result1 = str(snapshot1)
 print "Result length: " + str(len(result1)) + " characters"
-if result1 == "{\"snapshot\":null}" || result1 == "null" {
-  print "⚠️  Received null snapshot"
+if result1 == "{}" || result1 == "null" {
+  print "⚠️  Received empty snapshot"
 } else {
   print "✅ Received accessibility snapshot"
 }
@@ -51,8 +51,8 @@ call browser_get_accessibility_snapshot {
 
 set result2 = str(snapshot2)
 print "Result length: " + str(len(result2)) + " characters"
-if result2 == "{\"snapshot\":null}" || result2 == "null" {
-  print "⚠️  Received null snapshot"
+if result2 == "{}" || result2 == "null" {
+  print "⚠️  Received empty snapshot"
 } else {
   print "✅ Received accessibility snapshot"
 }
@@ -66,8 +66,8 @@ call browser_get_accessibility_snapshot {
 
 set result3 = str(snapshot3)
 print "Result length: " + str(len(result3)) + " characters"
-if result3 == "{\"snapshot\":null}" || result3 == "null" {
-  print "⚠️  Received null snapshot"
+if result3 == "{}" || result3 == "null" {
+  print "⚠️  Received empty snapshot"
 } else {
   print "✅ Received accessibility snapshot"
 }

--- a/examples/mcp-test/accessibility-test-simple.dsl
+++ b/examples/mcp-test/accessibility-test-simple.dsl
@@ -1,18 +1,82 @@
 # Simple Accessibility Snapshot Test
-# Tests the basic functionality of browser_get_accessibility_snapshot
+# Tests the browser_get_accessibility_snapshot tool with a known page
 
 # Connect to the MCP browser server
 connect "./bin/mcp-browser-server"
 
 # Wait for browser extension
-call browser_wait_for_connection {timeout: 5}
+print "Waiting for browser extension..."
+call browser_wait_for_connection {timeout: 30} -> connection_result
+print connection_result
 
-print "=== Testing Accessibility Snapshot Tool ==="
+print "\n=== Testing Accessibility Snapshot Tool ==="
 
-# Get snapshot and just print it as-is to see what we get
-call browser_get_accessibility_snapshot {} -> result
+# Create a new tab with a simple page
+print "\nCreating test tab..."
+call browser_create_tab {
+  url: "https://example.com",
+  active: true
+} -> tab
+print "Created tab ID: " + str(tab.id)
 
-print "\nRaw result:"
-print result
+# Wait for page to fully load
+print "Waiting for page to load..."
+call browser_wait_for_element {
+  tabId: tab.id,
+  selector: "h1",
+  timeout: 5000
+} -> wait_result
+print "Page loaded"
+
+# Test 1: Get accessibility snapshot with default settings
+print "\n1. Testing with default settings (interesting nodes only)..."
+call browser_get_accessibility_snapshot {
+  tabId: tab.id
+} -> snapshot1
+
+set result1 = str(snapshot1)
+print "Result length: " + str(len(result1)) + " characters"
+if result1 == "{\"snapshot\":null}" || result1 == "null" {
+  print "⚠️  Received null snapshot"
+} else {
+  print "✅ Received accessibility snapshot"
+}
+
+# Test 2: Get all nodes (not just interesting ones)
+print "\n2. Testing with all nodes..."
+call browser_get_accessibility_snapshot {
+  tabId: tab.id,
+  interestingOnly: false
+} -> snapshot2
+
+set result2 = str(snapshot2)
+print "Result length: " + str(len(result2)) + " characters"
+if result2 == "{\"snapshot\":null}" || result2 == "null" {
+  print "⚠️  Received null snapshot"
+} else {
+  print "✅ Received accessibility snapshot"
+}
+
+# Test 3: Get snapshot of specific element
+print "\n3. Testing with root selector (h1)..."
+call browser_get_accessibility_snapshot {
+  tabId: tab.id,
+  root: "h1"
+} -> snapshot3
+
+set result3 = str(snapshot3)
+print "Result length: " + str(len(result3)) + " characters"
+if result3 == "{\"snapshot\":null}" || result3 == "null" {
+  print "⚠️  Received null snapshot"
+} else {
+  print "✅ Received accessibility snapshot"
+}
+
+# Clean up
+print "\nCleaning up..."
+call browser_close_tab {
+  tabId: tab.id
+}
+print "Closed test tab"
 
 print "\n✓ Test completed!"

--- a/internal/browser/client.go
+++ b/internal/browser/client.go
@@ -735,7 +735,7 @@ func (c *Client) GetAccessibilitySnapshot(ctx context.Context, tabID int, intere
 		"tabId":           tabID,
 		"interestingOnly": interestingOnly,
 	}
-	
+
 	if root != "" {
 		params["root"] = root
 	}

--- a/internal/browser/client.go
+++ b/internal/browser/client.go
@@ -723,3 +723,27 @@ func stripHTMLTags(html string) string {
 
 	return strings.Join(cleanedLines, "\n")
 }
+
+// GetAccessibilitySnapshot gets the accessibility tree of the page
+func (c *Client) GetAccessibilitySnapshot(ctx context.Context, tabID int, interestingOnly bool, root string) (json.RawMessage, error) {
+	// Default to active tab if not specified
+	if tabID == 0 {
+		tabID = c.activeTabID
+	}
+
+	params := map[string]interface{}{
+		"tabId":           tabID,
+		"interestingOnly": interestingOnly,
+	}
+	
+	if root != "" {
+		params["root"] = root
+	}
+
+	result, err := c.sendCommand(ctx, "tabs.getAccessibilitySnapshot", params)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/internal/handler/browser_handler.go
+++ b/internal/handler/browser_handler.go
@@ -567,6 +567,20 @@ func (h *BrowserHandler) GetAccessibilitySnapshot(ctx context.Context, request m
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get accessibility snapshot: %v", err)), nil
 	}
 
-	// Return snapshot as JSON string
-	return mcp.NewToolResultText(string(snapshot)), nil
+	// Parse the response to extract the snapshot
+	var response struct {
+		Snapshot json.RawMessage `json:"snapshot"`
+	}
+	if err := json.Unmarshal(snapshot, &response); err != nil {
+		// If unmarshal fails, return the raw response
+		return mcp.NewToolResultText(string(snapshot)), nil
+	}
+
+	// If snapshot is null, return an empty object
+	if response.Snapshot == nil || string(response.Snapshot) == "null" {
+		return mcp.NewToolResultText("{}"), nil
+	}
+
+	// Return the snapshot directly
+	return mcp.NewToolResultText(string(response.Snapshot)), nil
 }

--- a/internal/handler/browser_handler.go
+++ b/internal/handler/browser_handler.go
@@ -555,3 +555,18 @@ func (h *BrowserHandler) ExtractText(ctx context.Context, request mcp.CallToolRe
 	// Return as plain text
 	return mcp.NewToolResultText(text), nil
 }
+
+// GetAccessibilitySnapshot gets the accessibility tree of the page
+func (h *BrowserHandler) GetAccessibilitySnapshot(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	tabID := request.GetInt("tabId", 0)
+	interestingOnly := request.GetBool("interestingOnly", true)
+	root := request.GetString("root", "")
+
+	snapshot, err := h.client.GetAccessibilitySnapshot(ctx, tabID, interestingOnly, root)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to get accessibility snapshot: %v", err)), nil
+	}
+
+	// Return snapshot as JSON string
+	return mcp.NewToolResultText(string(snapshot)), nil
+}

--- a/internal/handler/browser_handler_test.go
+++ b/internal/handler/browser_handler_test.go
@@ -1057,7 +1057,7 @@ func TestBrowserHandler_GetAccessibilitySnapshot(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, "RootWebArea", snapshot["role"])
 				assert.Equal(t, "Test Page", snapshot["name"])
-				
+
 				children := snapshot["children"].([]interface{})
 				assert.Len(t, children, 2)
 			},

--- a/internal/handler/browser_handler_test.go
+++ b/internal/handler/browser_handler_test.go
@@ -554,7 +554,7 @@ func TestBrowserHandler_CloseTab(t *testing.T) {
 				assert.NotNil(t, result)
 				require.Len(t, result.Content, 1)
 				text := getTextFromContent(t, result.Content[0])
-				assert.Contains(t, text, "tabId is required")
+				assert.Contains(t, text, "required argument \"tabId\" not found")
 			},
 		},
 		{
@@ -648,7 +648,7 @@ func TestBrowserHandler_Navigate(t *testing.T) {
 				},
 			},
 			setupMock: func(m *MockBrowserClient) {
-				m.On("Navigate", mock.Anything, 7, "https://google.com", false).Return(json.RawMessage(`{"success": true}`), nil)
+				m.On("Navigate", mock.Anything, 7, "https://google.com", true).Return(json.RawMessage(`{"success": true}`), nil)
 			},
 			wantErr: false,
 			checkResult: func(t *testing.T, result *mcp.CallToolResult) {
@@ -672,7 +672,7 @@ func TestBrowserHandler_Navigate(t *testing.T) {
 				assert.NotNil(t, result)
 				require.Len(t, result.Content, 1)
 				text := getTextFromContent(t, result.Content[0])
-				assert.Contains(t, text, "url is required")
+				assert.Contains(t, text, "required argument \"url\" not found")
 			},
 		},
 		{
@@ -686,7 +686,7 @@ func TestBrowserHandler_Navigate(t *testing.T) {
 				},
 			},
 			setupMock: func(m *MockBrowserClient) {
-				m.On("Navigate", mock.Anything, 0, "https://invalid.site", false).Return(json.RawMessage(nil), errors.New("failed to navigate"))
+				m.On("Navigate", mock.Anything, 0, "https://invalid.site", true).Return(json.RawMessage(nil), errors.New("failed to navigate"))
 			},
 			wantErr: false,
 			checkResult: func(t *testing.T, result *mcp.CallToolResult) {
@@ -789,7 +789,7 @@ func TestBrowserHandler_Click(t *testing.T) {
 				assert.NotNil(t, result)
 				require.Len(t, result.Content, 1)
 				text := getTextFromContent(t, result.Content[0])
-				assert.Contains(t, text, "selector is required")
+				assert.Contains(t, text, "required argument \"selector\" not found")
 			},
 		},
 		{

--- a/internal/handler/browser_handler_test.go
+++ b/internal/handler/browser_handler_test.go
@@ -1022,20 +1022,22 @@ func TestBrowserHandler_GetAccessibilitySnapshot(t *testing.T) {
 			name: "get accessibility snapshot successfully",
 			setupMock: func(m *MockBrowserClient) {
 				snapshot := json.RawMessage(`{
-					"role": "RootWebArea",
-					"name": "Test Page",
-					"children": [
-						{
-							"role": "heading",
-							"name": "Welcome",
-							"level": 1
-						},
-						{
-							"role": "button",
-							"name": "Submit",
-							"disabled": false
-						}
-					]
+					"snapshot": {
+						"role": "RootWebArea",
+						"name": "Test Page",
+						"children": [
+							{
+								"role": "heading",
+								"name": "Welcome",
+								"level": 1
+							},
+							{
+								"role": "button",
+								"name": "Submit",
+								"disabled": false
+							}
+						]
+					}
 				}`)
 				m.On("GetAccessibilitySnapshot", mock.Anything, 0, true, "").Return(snapshot, nil)
 			},
@@ -1066,8 +1068,10 @@ func TestBrowserHandler_GetAccessibilitySnapshot(t *testing.T) {
 			name: "get accessibility snapshot with specific parameters",
 			setupMock: func(m *MockBrowserClient) {
 				snapshot := json.RawMessage(`{
-					"role": "region",
-					"name": "Main Content"
+					"snapshot": {
+						"role": "region",
+						"name": "Main Content"
+					}
 				}`)
 				m.On("GetAccessibilitySnapshot", mock.Anything, 123, false, "#main").Return(snapshot, nil)
 			},
@@ -1112,6 +1116,27 @@ func TestBrowserHandler_GetAccessibilitySnapshot(t *testing.T) {
 				text := getTextFromContent(t, result.Content[0])
 				assert.Contains(t, text, "Failed to get accessibility snapshot")
 				assert.Contains(t, text, "page not accessible")
+			},
+		},
+		{
+			name: "get accessibility snapshot with null result",
+			setupMock: func(m *MockBrowserClient) {
+				snapshot := json.RawMessage(`{"snapshot": null}`)
+				m.On("GetAccessibilitySnapshot", mock.Anything, 0, true, "").Return(snapshot, nil)
+			},
+			request: mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name:      "browser_get_accessibility_snapshot",
+					Arguments: map[string]interface{}{},
+				},
+			},
+			wantErr: false,
+			checkResult: func(t *testing.T, result *mcp.CallToolResult) {
+				assert.NotNil(t, result)
+				require.Len(t, result.Content, 1)
+				text := getTextFromContent(t, result.Content[0])
+				// Should return empty object when snapshot is null
+				assert.Equal(t, "{}", text)
 			},
 		},
 	}

--- a/internal/handler/interfaces.go
+++ b/internal/handler/interfaces.go
@@ -52,7 +52,7 @@ type BrowserClient interface {
 
 	// Actionables
 	GetActionables(ctx context.Context, tabID int) ([]browser.Actionable, error)
-	
+
 	// Accessibility
 	GetAccessibilitySnapshot(ctx context.Context, tabID int, interestingOnly bool, root string) (json.RawMessage, error)
 }

--- a/internal/handler/interfaces.go
+++ b/internal/handler/interfaces.go
@@ -52,4 +52,7 @@ type BrowserClient interface {
 
 	// Actionables
 	GetActionables(ctx context.Context, tabID int) ([]browser.Actionable, error)
+	
+	// Accessibility
+	GetAccessibilitySnapshot(ctx context.Context, tabID int, interestingOnly bool, root string) (json.RawMessage, error)
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -67,6 +67,7 @@ func (s *Server) registerTools() {
 	s.registerExtractTextTool()
 	s.registerScreenshotTool()
 	s.registerGetActionablesTool()
+	s.registerGetAccessibilitySnapshotTool()
 
 	// Storage Tools
 	s.registerCookieTools()
@@ -378,6 +379,25 @@ func (s *Server) registerGetActionablesTool() {
 
 	s.mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return s.handler.GetActionables(ctx, request)
+	})
+}
+
+func (s *Server) registerGetAccessibilitySnapshotTool() {
+	tool := mcp.NewTool("browser_get_accessibility_snapshot",
+		mcp.WithDescription("Get the accessibility tree of the page for understanding page structure and elements"),
+		mcp.WithNumber("tabId",
+			mcp.Description("Tab ID to get snapshot from (defaults to active tab)"),
+		),
+		mcp.WithBoolean("interestingOnly",
+			mcp.Description("Only return nodes with semantic meaning (default: true)"),
+		),
+		mcp.WithString("root",
+			mcp.Description("CSS selector for the root element to start from (defaults to document body)"),
+		),
+	)
+
+	s.mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return s.handler.GetAccessibilitySnapshot(ctx, request)
 	})
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -100,6 +100,10 @@ func (m *MockBrowserClient) GetActionables(ctx context.Context, tabID int) ([]br
 	return nil, nil
 }
 
+func (m *MockBrowserClient) GetAccessibilitySnapshot(ctx context.Context, tabID int, interestingOnly bool, root string) (json.RawMessage, error) {
+	return nil, nil
+}
+
 func TestNewServer(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary
- Implements the `browser_get_accessibility_snapshot` MCP tool for retrieving accessibility trees from web pages
- Leverages the existing `tabs.getAccessibilitySnapshot` command in the browser extension
- Provides semantic information about DOM elements including ARIA roles, names, and properties

## Implementation Details
- Added `GetAccessibilitySnapshot` method to the `BrowserClient` interface
- Implemented handler method in `browser_handler.go` that processes MCP tool requests
- Registered the tool in the MCP server with configurable parameters:
  - `tabId`: Target tab (defaults to active tab)
  - `interestingOnly`: Filter to only semantically meaningful nodes (default: true)
  - `root`: CSS selector for root element (defaults to document body)
- Added comprehensive unit tests covering success cases, parameter variations, and error handling

## Test Plan
- [x] Unit tests pass for the new handler method
- [x] Verified the browser extension already implements the command
- [ ] Manual testing with browser extension to verify accessibility tree retrieval
- [ ] Test with various web pages to ensure proper tree structure